### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ build: info
 		${INCLUDEFILES}
 
 tar.gz: build
-	${TAR} zcf ModuleManager-0.$(shell ${GIT} rev-list --count HEAD).g$(shell ${GIT} log -1 --format="%h").tar.gz build/ModuleManager.dll
+	${TAR} zcf ModuleManager-0.$(shell ${GIT} rev-list --count HEAD).g$(shell ${GIT} log -1 --format="%h").tar.gz ModuleManager.version build/ModuleManager.dll
 
 zip: build
-	${ZIP} -9 -r ModuleManager-0.$(shell ${GIT} rev-list --count HEAD).g$(shell ${GIT} log -1 --format="%h").zip build/ModuleManager.dll
+	${ZIP} -9 -r ModuleManager-0.$(shell ${GIT} rev-list --count HEAD).g$(shell ${GIT} log -1 --format="%h").zip ModuleManager.version build/ModuleManager.dll
 
 clean:
 	@echo "Cleaning up build and package directories..."

--- a/ModuleManager.version
+++ b/ModuleManager.version
@@ -1,0 +1,14 @@
+{
+  "NAME": "ModuleManager",
+  "URL": "https://raw.githubusercontent.com/sarbian/ModuleManager/master/ModuleManager.version",
+  "VERSION": {
+    "MAJOR": 2,
+    "MINOR": 0,
+    "PATCH": 7
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}


### PR DESCRIPTION
Dearest MM authors/maintainers,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)

**Note**: I've tried to work it into your Makefile but please let me know if I screwed anything up and I'll happily fix it. Btw, I love that you have a Makefile, more people should be doing this! :)
