### PR TITLE
Allow ~ to take an argument

### DIFF
--- a/moduleManager.cs
+++ b/moduleManager.cs
@@ -1003,8 +1003,12 @@ namespace ModuleManager
                         return false;
                     case '~':
                         // ~breakingForce[]  breakingForce is not present
+                        // or: ~breakingForce[100]  will be true if it's present but not 100, too.
                         if (!(node.HasValue(type)))
                             return CheckCondition(node, remainCond);
+                        if(name != null && node.GetValue(type).Equals(name))
+                            return CheckCondition(node, remainCond);
+                            
                         return false;
                     default:
                         return false;


### PR DESCRIPTION
~key[foo] returns false to the HAS[] if and only if key is present and = foo. This way you can do HAS[~crewCapacity[0]] to get all crewed parts, for example.
