### PR TITLE
Re-enable SaveGameFixer and improve it to also run on canned stock craft dirs

### DIFF
--- a/SaveGameFixer.cs
+++ b/SaveGameFixer.cs
@@ -67,10 +67,10 @@ namespace ModuleManager
 
                 UpdateSaves();
 
-				char ds = Path.DirectorySeparatorChar;
+                char ds = Path.DirectorySeparatorChar;
 
-				UpdateCraftDir(string.Format("{0}{1}Ships{1}VAB", KSPUtil.ApplicationRootPath, ds));
-				UpdateCraftDir(string.Format("{0}{1}Ships{1}SPH", KSPUtil.ApplicationRootPath, ds));
+                UpdateCraftDir(Path.Combine(KSPUtil.ApplicationRootPath, string.Format("Ships{0}VAB", ds)), KSPUtil.ApplicationRootPath);
+                UpdateCraftDir(Path.Combine(KSPUtil.ApplicationRootPath, string.Format("Ships{0}VAB", ds)), KSPUtil.ApplicationRootPath);
             }
             catch (Exception ex)
             {
@@ -149,7 +149,7 @@ namespace ModuleManager
             }
         }
 
-        private void UpdateCraftDir(string dir)
+        private void UpdateCraftDir(string dir, string rootDir)
         {
             string[] files;
             try
@@ -162,14 +162,19 @@ namespace ModuleManager
             }
             foreach (string vabCraft in files)
                 if (vabCraft.EndsWith(".craft"))
-                    UpdateCraft(vabCraft);
+                    UpdateCraft(vabCraft, rootDir);
         }
 
-        private void UpdateCraft(string vabCraft)
+        private void UpdateCraftDir(string dir)
+        {
+            UpdateCraftDir(dir, savesRoot);
+        }
+
+        private void UpdateCraft(string vabCraft, string rootDir)
         {
             try
             {
-                PushLogContext("Craft file: " + vabCraft.Substring(savesRoot.Length, vabCraft.Length-savesRoot.Length));
+                PushLogContext("Craft file: " + vabCraft.Substring(rootDir.Length, vabCraft.Length-rootDir.Length));
                 ConfigNode craft = ConfigNode.Load(vabCraft);
 
                 needsBackup = false; needsSave = false; partMissing = false;
@@ -184,7 +189,7 @@ namespace ModuleManager
                     WriteDebugMessage("Delete the craft to get rid of this message.");
                 }
 
-                BackupAndReplace(vabCraft, craft);
+                BackupAndReplace(vabCraft, rootDir, craft);
 
 
             }
@@ -192,6 +197,11 @@ namespace ModuleManager
             {
                 PopLogContext();
             }
+        }
+
+        private void UpdateCraft(string vabCraft)
+        {
+            UpdateCraft(vabCraft, savesRoot);
         }
 
         private void UpdateSFS(string sfsFile)
@@ -475,14 +485,14 @@ namespace ModuleManager
             }
         }
 
-        private void BackupAndReplace(string file, ConfigNode config)
+        private void BackupAndReplace(string file, string rootDir, ConfigNode config)
         {
 
             if (needsBackup)
             {
                 CreateBackupDir();
 
-                string relPath = file.Substring(savesRoot.Length, file.Length - savesRoot.Length);
+                string relPath = file.Substring(rootDir.Length, file.Length - rootDir.Length);
 
                 string backupTo = Path.Combine(backupDir, relPath);
                 // ReSharper disable once AssignNullToNotNullAttribute
@@ -495,6 +505,11 @@ namespace ModuleManager
 
             if(needsSave)
                 config.Save(file);
+        }
+
+        private void BackupAndReplace(string File, ConfigNode config)
+        {
+            BackupAndReplace(File, savesRoot, config);
         }
 
         #endregion


### PR DESCRIPTION
These commits re-enable the SaveGameFixer, add functionality necessary to operate outside the "saves" dir, and adds update runs on the canned "Ships" dir that ships with KSP.

I've done nominal testing only on a lightly modded install: game loads without exception, Kerbal X loads up, DecoupleForX64 and TweakableDecouplers play nicely together, ship flies, decouplers work.
