### PR TITLE
load KSP assemblies from the configured KspDir env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ ModuleManager.csproj
 ModuleManager.csproj.user
 
 ModuleManager.*.dll
+LocalProperties.props

--- a/ModuleManager.csproj
+++ b/ModuleManager.csproj
@@ -34,18 +34,28 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SaveGameFixer.cs" />
   </ItemGroup>
+  <Import Condition="exists('$(MSBuildProjectDirectory)\LocalProperties.props')" Project="$(MSBuildProjectDirectory)\LocalProperties.props"/>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="System" />
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(KspDir)\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e, processorArchitecture=MSIL" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="UnityEngine">
+      <HintPath>$(KspDir)\KSP_Data\Managed\UnityEngine.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="BeforeBuild">
+    <Error Condition="'$(KspDir)' == ''" Text="Unable to find KSP assemblies. Create a property KspDir in LocalProperties.props or setup an environmental variable KspDir that points to the KSP installation directory."/>
+  </Target>
   <PropertyGroup>
-    <PostBuildEvent>echo copying to "%25KSPDIR%25\GameData\"
-copy "$(TargetPath)" "%25KSPDIR%25\GameData\"</PostBuildEvent>
+    <PostBuildEvent>
+      echo copying to "$(KspDir)\GameData\"
+      copy "$(TargetPath)" "$(KspDir)\GameData\"
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This should make it possible to clone the repo and just hit build. (If there's a KspDir env var already set up)

Without $(KspDir), an error will be shown in the IDE/msbuild that explains which env var to create or where to put the msbuild property.
