### PR TITLE
use mcs instead of gmcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INCLUDEFILES := $(wildcard *.cs) \
 	$(wildcard Properties/*.cs)
 
 RESGEN2 := resgen2
-GMCS    := /usr/bin/gmcs
+MCS     := /usr/bin/mcs
 GIT     := /usr/bin/git
 TAR     := /usr/bin/tar
 ZIP     := /usr/bin/zip
@@ -16,7 +16,7 @@ all: build
 
 info:
 	@echo "== ModuleManager Build Information =="
-	@echo "  gmcs:    ${GMCS}"
+	@echo "  mcs:     ${MCS}"
 	@echo "  git:     ${GIT}"
 	@echo "  tar:     ${TAR}"
 	@echo "  zip:     ${ZIP}"
@@ -26,7 +26,7 @@ info:
 build: info
 	mkdir -p build
 	${RESGEN2} -usesourcepath Properties/Resources.resx build/Resources.resources
-	${GMCS} -t:library -lib:${KSPDIR}/${MANAGED} \
+	${MCS} -t:library -lib:${KSPDIR}/${MANAGED} \
 		-r:Assembly-CSharp,Assembly-CSharp-firstpass,UnityEngine \
 		-out:build/ModuleManager.dll \
 		-resource:build/Resources.resources,ModuleManager.Properties.Resources.resources \


### PR DESCRIPTION
See http://www.mono-project.com/docs/about-mono/languages/csharp/ for
futher information; gmcs, smcs, and dmcs targeted different versions of
mscorlib, but more modern mono distributions, e.g.

deb http://download.mono-project.com/repo/debian wheezy main

tend to not have gmcs present.  Mono's recommendation here is to use
mcs.  If mcs is not as widely deployed as I suspect, then an autodetect
should check for gmcs or mcs presence.