### PR TITLE
Implemented Math on Vectors

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("2.6.13")]
+[assembly: AssemblyVersion("2.6.14")]
 [assembly: KSPAssembly("ModuleManager", 2, 5)]
 
 // The following attributes are used to specify the signing key for the assembly, 

--- a/moduleManager.cs
+++ b/moduleManager.cs
@@ -1452,7 +1452,7 @@ namespace ModuleManager
         }
 
         // Name is group 1, index is group 2, operator is group 3
-        private static Regex parseValue = new Regex(@"([\w\&\-\.\?\*]*)(?:,(-?[0-9\*]+))(?:\[(-?[0-9\*]+))(?:,-?(.)+\])?(?:\s([+\-*/^!]))?");
+        private static Regex parseValue = new Regex(@"([\w\&\-\.\?\*]*)(?:,(-?[0-9\*]+))?(?:\[((?:[0-9]+)+)(?:,(.))?\])?(?:\s([+\-*/^!]))?");
 
         // ModifyNode applies the ConfigNode mod as a 'patch' to ConfigNode original, then returns the patched ConfigNode.
         // it uses FindConfigNodeIn(src, nodeType, nodeName, nodeTag) to recurse.


### PR DESCRIPTION
Hi Sarbian.
I was so free and implemented @Sigma88's specifications for Math on Vectors, as stated in #37 
It is a bit hacky, but I hope that you are fine with this. If not, I will redo it based on your opinion. :)

The syntax is pretty easy. If you have a node that looks like this:
```
NODE
{
    key = 0 1 0 1
    key = 1 0 1 0
    key = 1 1 0 0
    key = 0 0 1 1
}
```

and you do 
```
@NODE
{
    @key,*[0, ] += 1
}
```

you will get
```
NODE
{
    key = 1 1 0 1
    key = 2 0 1 0
    key = 2 1 0 0
    key = 1 0 1 1
}
```

The seperator (i.e. the part after **[index,**) defaults to ",", in this example I set it to a space. You can replace the index with a star to edit all the values in the vector.

I hope that you (and @Sigma88 ) will like it. :) If I broke something, please tell me and I will fix it ASAP.

Cheers!
-Thomas