### PR TITLE
Reload PartUpgrade System after patching

### DIFF
--- a/moduleManager.cs
+++ b/moduleManager.cs
@@ -367,6 +367,8 @@ namespace ModuleManager
                 MMPatchLoader.Instance.needsUnsatisfiedCount + " exceptionCount=" + MMPatchLoader.Instance.exceptionCount);
 
             PartResourceLibrary.Instance.LoadDefinitions();
+            
+            PartUpgradeManager.Handler.FillUpgrades();
 
             if (dump)
                 OutputAllConfigs();
@@ -896,6 +898,9 @@ namespace ModuleManager
 
             log("Reloading Trait configs");
             GameDatabase.Instance.ExperienceConfigs.LoadTraitConfigs();
+            
+            log("Reloading Part Upgrades");
+            PartUpgradeManager.Handler.FillUpgrades();
 
             foreach (ModuleManagerPostPatchCallback callback in postPatchCallbacks)
             {


### PR DESCRIPTION
As the part-upgrade data is initially populated prior to ModuleManager patching, this fix allows for the patches that are applied to the PARTUPGRADE nodes to be reloaded for use by the PartUpgrade system.  With this fix in place the tech-nodes, names, descriptions, etc, for the part-upgrade parts located on the tech tree will use the proper post-patching config data.

This solution has been tested to work properly when used directly from a ModuleManagerPostLoad callback.

Fix for problems discovered in https://github.com/KSP-RO/RealismOverhaul/pull/1628