### PR TITLE
Sort passes first

### DIFF
--- a/ModuleManager/Collections/ArrayEnumerator.cs
+++ b/ModuleManager/Collections/ArrayEnumerator.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ModuleManager.Collections
+{
+    public struct ArrayEnumerator<T> : IEnumerator<T>
+    {
+        private readonly T[] array;
+        private int index;
+
+        public ArrayEnumerator(T[] array)
+        {
+            this.array = array;
+            index = -1;
+        }
+
+        public T Current => array[index];
+        object IEnumerator.Current => Current;
+
+        public void Dispose() { }
+
+        public bool MoveNext()
+        {
+            index++;
+            return index < array.Length;
+        }
+
+        public void Reset()
+        {
+            index = -1;
+        }
+    }
+}

--- a/ModuleManager/Command.cs
+++ b/ModuleManager/Command.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ModuleManager
+{
+    public enum Command
+    {
+        Insert,
+
+        Delete,
+
+        Edit,
+
+        Replace,
+
+        Copy,
+
+        Rename,
+
+        Paste,
+
+        Special,
+
+        Create
+    }
+}

--- a/ModuleManager/CommandParser.cs
+++ b/ModuleManager/CommandParser.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ModuleManager
+{
+    public static class CommandParser
+    {
+        public static Command Parse(string name, out string valueName)
+        {
+            if (name.Length == 0)
+            {
+                valueName = string.Empty;
+                return Command.Insert;
+            }
+            Command ret;
+            switch (name[0])
+            {
+                case '@':
+                    ret = Command.Edit;
+                    break;
+
+                case '%':
+                    ret = Command.Replace;
+                    break;
+
+                case '-':
+                case '!':
+                    ret = Command.Delete;
+                    break;
+
+                case '+':
+                case '$':
+                    ret = Command.Copy;
+                    break;
+
+                case '|':
+                    ret = Command.Rename;
+                    break;
+
+                case '#':
+                    ret = Command.Paste;
+                    break;
+
+                case '*':
+                    ret = Command.Special;
+                    break;
+
+                case '&':
+                    ret = Command.Create;
+                    break;
+
+                default:
+                    valueName = name;
+                    return Command.Insert;
+            }
+            valueName = name.Substring(1);
+            return ret;
+        }
+    }
+}

--- a/ModuleManager/Extensions/ConfigNodeExtensions.cs
+++ b/ModuleManager/Extensions/ConfigNodeExtensions.cs
@@ -16,6 +16,7 @@ namespace ModuleManager.Extensions
                 toNode.nodes.Add(node);
         }
 
+        // KSP implementation of ConfigNode.CreateCopy breaks with badly formed nodes (nodes with a blank name)
         public static ConfigNode DeepCopy(this ConfigNode from)
         {
             ConfigNode to = new ConfigNode(from.name);

--- a/ModuleManager/Extensions/ConfigNodeExtensions.cs
+++ b/ModuleManager/Extensions/ConfigNodeExtensions.cs
@@ -15,5 +15,18 @@ namespace ModuleManager.Extensions
             foreach (ConfigNode node in fromeNode.nodes)
                 toNode.nodes.Add(node);
         }
+
+        public static ConfigNode DeepCopy(this ConfigNode from)
+        {
+            ConfigNode to = new ConfigNode(from.name);
+            foreach (ConfigNode.Value value in from.values)
+                to.AddValue(value.name, value.value);
+            foreach (ConfigNode node in from.nodes)
+            {
+                ConfigNode newNode = DeepCopy(node);
+                to.nodes.Add(newNode);
+            }
+            return to;
+        }
     }
 }

--- a/ModuleManager/Extensions/ConfigNodeExtensions.cs
+++ b/ModuleManager/Extensions/ConfigNodeExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ModuleManager.Extensions
+{
+    public static class ConfigNodeExtensions
+    {
+        public static void ShallowCopyFrom(this ConfigNode toNode, ConfigNode fromeNode)
+        {
+            toNode.ClearData();
+            foreach (ConfigNode.Value value in fromeNode.values)
+                toNode.values.Add(value);
+            foreach (ConfigNode node in fromeNode.nodes)
+                toNode.nodes.Add(node);
+        }
+    }
+}

--- a/ModuleManager/Extensions/ConfigNodeExtensions.cs
+++ b/ModuleManager/Extensions/ConfigNodeExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ModuleManager.Extensions
 {

--- a/ModuleManager/Extensions/StringExtensions.cs
+++ b/ModuleManager/Extensions/StringExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ModuleManager.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool IsBracketBalanced(this string s)
+        {
+            int level = 0;
+            foreach (char c in s)
+            {
+                if (c == '[') level++;
+                else if (c == ']') level--;
+
+                if (level < 0) return false;
+            }
+            return level == 0;
+        }
+    }
+}

--- a/ModuleManager/Extensions/UrlConfigExtensions.cs
+++ b/ModuleManager/Extensions/UrlConfigExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ModuleManager.Extensions
+{
+    public static class UrlConfigExtensions
+    {
+        public static string SafeUrl(this UrlDir.UrlConfig url)
+        {
+            if (url == null) return "<null>";
+
+            string nodeName;
+
+            if (!string.IsNullOrEmpty(url.type?.Trim()))
+            {
+                nodeName = url.type;
+            }
+            else if (!string.IsNullOrEmpty(url.config?.name?.Trim()))
+            {
+                nodeName = url.config.name;
+            }
+            else
+            {
+                nodeName = "<blank>";
+            }
+
+            string parentUrl = null;
+
+            if (url.parent != null)
+            {
+                try
+                {
+                    parentUrl = url.parent.url;
+                }
+                catch
+                {
+                    parentUrl = "<unknown>";
+                }
+            }
+
+            if (parentUrl == null)
+                return nodeName;
+            else
+                return parentUrl + "/" + nodeName;
+        }
+    }
+}

--- a/ModuleManager/IPatchProgress.cs
+++ b/ModuleManager/IPatchProgress.cs
@@ -21,6 +21,9 @@ namespace ModuleManager
         void NeedsUnsatisfiedRoot(UrlDir.UrlConfig url);
         void NeedsUnsatisfiedNode(UrlDir.UrlConfig url, NodeStack path);
         void NeedsUnsatisfiedValue(UrlDir.UrlConfig url, NodeStack path, string valName);
+        void NeedsUnsatisfiedBefore(UrlDir.UrlConfig url);
+        void NeedsUnsatisfiedFor(UrlDir.UrlConfig url);
+        void NeedsUnsatisfiedAfter(UrlDir.UrlConfig url);
         void ApplyingCopy(UrlDir.UrlConfig original, UrlDir.UrlConfig patch);
         void ApplyingDelete(UrlDir.UrlConfig original, UrlDir.UrlConfig patch);
         void ApplyingUpdate(UrlDir.UrlConfig original, UrlDir.UrlConfig patch);

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -1036,14 +1036,8 @@ namespace ModuleManager
                                             url.parent.configs.Remove(url);
                                             break;
 
-                                        case Command.Replace:
-
-                                            // TODO: do something sensible here.
-                                            break;
-
-                                        case Command.Create:
-
-                                            // TODO: something similar to above
+                                        default:
+                                            logger.Warning("Invalid command encountered on a root node: " + mod.SafeUrl());
                                             break;
                                     }
                                     // When this special node is found then try to apply the patch once more on the same NODE

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -184,7 +184,7 @@ namespace ModuleManager
             modlist += "Non-DLL mods added (:FOR[xxx]):\n";
             foreach (UrlDir.UrlConfig cfgmod in GameDatabase.Instance.root.AllConfigs)
             {
-                if (ParseCommand(cfgmod.type, out string name) != Command.Insert)
+                if (CommandParser.Parse(cfgmod.type, out string name) != Command.Insert)
                 {
                     progress.PatchAdded();
                     if (name.Contains(":FOR["))
@@ -940,7 +940,7 @@ namespace ModuleManager
             {
                 string name = RemoveWS(mod.type);
 
-                if (ParseCommand(name, out name) != Command.Insert)
+                if (CommandParser.Parse(name, out name) != Command.Insert)
                     mod.parent.configs.Remove(mod);
             }
         }
@@ -968,7 +968,7 @@ namespace ModuleManager
                 try
                 {
                     string name = RemoveWS(mod.type);
-                    Command cmd = ParseCommand(name, out string tmp);
+                    Command cmd = CommandParser.Parse(name, out string tmp);
 
                     if (cmd != Command.Insert)
                     {
@@ -1124,7 +1124,7 @@ namespace ModuleManager
                 vals += "\n   " + modVal.name + "= " + modVal.value;
                 #endif
 
-                Command cmd = ParseCommand(modVal.name, out string valName);
+                Command cmd = CommandParser.Parse(modVal.name, out string valName);
 
                 if (cmd == Command.Special)
                 {
@@ -1424,7 +1424,7 @@ namespace ModuleManager
                 }
 
                 string subName = subMod.name;
-                Command command = ParseCommand(subName, out string tmp);
+                Command command = CommandParser.Parse(subName, out string tmp);
 
                 if (command == Command.Insert)
                 {
@@ -2067,83 +2067,6 @@ namespace ModuleManager
         }
 
         #endregion Applying Patches
-
-        #region Command Parsing
-
-        private enum Command
-        {
-            Insert,
-
-            Delete,
-
-            Edit,
-
-            Replace,
-
-            Copy,
-
-            Rename,
-
-            Paste,
-
-            Special,
-
-            Create
-        }
-
-        private static Command ParseCommand(string name, out string valueName)
-        {
-            if (name.Length == 0)
-            {
-                valueName = string.Empty;
-                return Command.Insert;
-            }
-            Command ret;
-            switch (name[0])
-            {
-                case '@':
-                    ret = Command.Edit;
-                    break;
-
-                case '%':
-                    ret = Command.Replace;
-                    break;
-
-                case '-':
-                case '!':
-                    ret = Command.Delete;
-                    break;
-
-                case '+':
-                case '$':
-                    ret = Command.Copy;
-                    break;
-
-                case '|':
-                    ret = Command.Rename;
-                    break;
-
-                case '#':
-                    ret = Command.Paste;
-                    break;
-
-                case '*':
-                    ret = Command.Special;
-                    break;
-
-                case '&':
-                    ret = Command.Create;
-                    break;
-
-                default:
-                    valueName = name;
-                    return Command.Insert;
-            }
-            valueName = name.Substring(1);
-            return ret;
-        }
-
-        #endregion Command Parsing
 
         #region Sanity checking & Utility functions
 

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -812,7 +812,7 @@ namespace ModuleManager
                 }
                 catch (Exception ex)
                 {
-                    progress.Exception(currentMod, "Exception while checking needs : " + currentMod.url + " with a type of " + currentMod.type, ex);
+                    progress.Exception(currentMod, "Exception while checking needs : " + currentMod.SafeUrl() + " with a type of " + currentMod.type, ex);
                     logger.Error("Node is : " + PrettyConfig(currentMod));
                 }
             }
@@ -858,7 +858,7 @@ namespace ModuleManager
 
                 if (nodeName == null)
                 {
-                    progress.Error(context.patchUrl, "Error - Node in file " + context.patchUrl.url + " subnode: " + stack.GetPath() +
+                    progress.Error(context.patchUrl, "Error - Node in file " + context.patchUrl.SafeUrl() + " subnode: " + stack.GetPath() +
                             " has config.name == null");
                 }
 
@@ -1063,7 +1063,7 @@ namespace ModuleManager
                                             // When this special node is found then try to apply the patch once more on the same NODE
                                             if (mod.config.HasNode("MM_PATCH_LOOP"))
                                             {
-                                                logger.Info("Looping on " + mod.url + " to " + url.url);
+                                                logger.Info("Looping on " + mod.SafeUrl() + " to " + url.SafeUrl());
                                                 loop = true;
                                             }
                                         }
@@ -1085,7 +1085,7 @@ namespace ModuleManager
                 }
                 catch (Exception e)
                 {
-                    progress.Exception(mod, "Exception while processing node : " + mod.url, e);
+                    progress.Exception(mod, "Exception while processing node : " + mod.SafeUrl(), e);
                     logger.Error("Processed node was\n" + PrettyConfig(mod));
                     mod.parent.configs.Remove(mod);
                 }

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -1108,7 +1108,7 @@ namespace ModuleManager
         // it uses FindConfigNodeIn(src, nodeType, nodeName, nodeTag) to recurse.
         public static ConfigNode ModifyNode(NodeStack original, ConfigNode mod, PatchContext context)
         {
-            ConfigNode newNode = original.value.CreateCopy();
+            ConfigNode newNode = original.value.DeepCopy();
             NodeStack nodeStack = original.ReplaceValue(newNode);
 
             #region Values

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -2074,11 +2074,6 @@ namespace ModuleManager
             return new string(withWhite.ToCharArray().Where(c => !Char.IsWhiteSpace(c)).ToArray());
         }
 
-        public bool IsPathInList(string modPath, List<string> pathList)
-        {
-            return pathList.Any(modPath.StartsWith);
-        }
-
         #endregion Sanity checking & Utility functions
 
         #region Condition checking

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -970,7 +970,7 @@ namespace ModuleManager
 
                     if (cmd != Command.Insert)
                     {
-                        if (!IsBracketBalanced(mod.type))
+                        if (!mod.type.IsBracketBalanced())
                         {
                             progress.Error(mod,
                                 "Error - Skipping a patch with unbalanced square brackets or a space (replace them with a '?') :\n" +
@@ -1413,7 +1413,7 @@ namespace ModuleManager
             {
                 subMod.name = RemoveWS(subMod.name);
 
-                if (!IsBracketBalanced(subMod.name))
+                if (!subMod.name.IsBracketBalanced())
                 {
                     context.progress.Error(context.patchUrl,
                         "Error - Skipping a patch subnode with unbalanced square brackets or a space (replace them with a '?') in "
@@ -2067,29 +2067,6 @@ namespace ModuleManager
         #endregion Applying Patches
 
         #region Sanity checking & Utility functions
-
-        public static bool IsBracketBalanced(string str)
-        {
-            Stack<char> stack = new Stack<char>();
-
-            char c;
-            for (int i = 0; i < str.Length; i++)
-            {
-                c = str[i];
-                if (c == '[')
-                    stack.Push(c);
-                else if (c == ']')
-                {
-                    if (stack.Count == 0)
-                        return false;
-                    if (stack.Peek() == '[')
-                        stack.Pop();
-                    else
-                        return false;
-                }
-            }
-            return stack.Count == 0;
-        }
 
         public static string RemoveWS(string withWhite)
         {

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -1454,7 +1454,7 @@ namespace ModuleManager
                     //string newName = subName.Substring(0, start);
                     //string path = subName.Substring(start + 1, end - start - 1);
 
-                    ConfigNode toPaste = RecurseNodeSearch(subName.Substring(1), nodeStack.Pop(), context);
+                    ConfigNode toPaste = RecurseNodeSearch(subName.Substring(1), nodeStack, context);
 
                     if (toPaste == null)
                     {

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -981,88 +981,81 @@ namespace ModuleManager
                     if (cmd != Command.Insert)
                     {
                         string upperName = name.ToUpper();
+                        PatchContext context = new PatchContext(mod, GameDatabase.Instance.root, logger, progress);
+                        char[] sep = { '[', ']' };
+                        string condition = "";
 
-                        try
+                        if (upperName.Contains(":HAS["))
                         {
-                            PatchContext context = new PatchContext(mod, GameDatabase.Instance.root, logger, progress);
-                            char[] sep = { '[', ']' };
-                            string condition = "";
-
-                            if (upperName.Contains(":HAS["))
-                            {
-                                int start = upperName.IndexOf(":HAS[");
-                                condition = name.Substring(start + 5, name.LastIndexOf(']') - start - 5);
-                                name = name.Substring(0, start);
-                            }
-
-                            string[] splits = name.Split(sep, 3);
-                            string[] patterns = splits.Length > 1 ? splits[1].Split(',', '|') : new string[] { null };
-                            string type = splits[0].Substring(1);
-
-                            foreach (UrlDir.UrlConfig url in GameDatabase.Instance.root.AllConfigs.ToArray())
-                            {
-                                foreach (string pattern in patterns)
-                                {
-                                    bool loop = false;
-                                    do
-                                    {
-                                        if (url.type == type && WildcardMatch(url.name, pattern)
-                                            && CheckConstraints(url.config, condition))
-                                        {
-                                            switch (cmd)
-                                            {
-                                                case Command.Edit:
-                                                    progress.ApplyingUpdate(url, mod);
-                                                    url.config = ModifyNode(new NodeStack(url.config), mod.config, context);
-                                                    break;
-
-                                                case Command.Copy:
-                                                    ConfigNode clone = ModifyNode(new NodeStack(url.config), mod.config, context);
-                                                    if (url.config.name != mod.name)
-                                                    {
-                                                        progress.ApplyingCopy(url, mod);
-                                                        url.parent.configs.Add(new UrlDir.UrlConfig(url.parent, clone));
-                                                    }
-                                                    else
-                                                    {
-                                                        progress.Error(mod, "Error - Error while processing " + mod.config.name +
-                                                            " the copy needs to have a different name than the parent (use @name = xxx)");
-                                                    }
-                                                    break;
-
-                                                case Command.Delete:
-                                                    progress.ApplyingDelete(url, mod);
-                                                    url.parent.configs.Remove(url);
-                                                    break;
-
-                                                case Command.Replace:
-
-                                                    // TODO: do something sensible here.
-                                                    break;
-
-                                                case Command.Create:
-
-                                                    // TODO: something similar to above
-                                                    break;
-                                            }
-                                            // When this special node is found then try to apply the patch once more on the same NODE
-                                            if (mod.config.HasNode("MM_PATCH_LOOP"))
-                                            {
-                                                logger.Info("Looping on " + mod.SafeUrl() + " to " + url.SafeUrl());
-                                                loop = true;
-                                            }
-                                        }
-                                        else
-                                        {
-                                            loop = false;
-                                        }
-                                    } while (loop);
-
-                                }
-                            }
+                            int start = upperName.IndexOf(":HAS[");
+                            condition = name.Substring(start + 5, name.LastIndexOf(']') - start - 5);
+                            name = name.Substring(0, start);
                         }
-                        finally
+
+                        string[] splits = name.Split(sep, 3);
+                        string[] patterns = splits.Length > 1 ? splits[1].Split(',', '|') : new string[] { null };
+                        string type = splits[0].Substring(1);
+
+                        foreach (UrlDir.UrlConfig url in GameDatabase.Instance.root.AllConfigs.ToArray())
                         {
+                            foreach (string pattern in patterns)
+                            {
+                                bool loop = false;
+                                do
+                                {
+                                    if (url.type == type && WildcardMatch(url.name, pattern)
+                                        && CheckConstraints(url.config, condition))
+                                    {
+                                        switch (cmd)
+                                        {
+                                            case Command.Edit:
+                                                progress.ApplyingUpdate(url, mod);
+                                                url.config = ModifyNode(new NodeStack(url.config), mod.config, context);
+                                                break;
+
+                                            case Command.Copy:
+                                                ConfigNode clone = ModifyNode(new NodeStack(url.config), mod.config, context);
+                                                if (url.config.name != mod.name)
+                                                {
+                                                    progress.ApplyingCopy(url, mod);
+                                                    url.parent.configs.Add(new UrlDir.UrlConfig(url.parent, clone));
+                                                }
+                                                else
+                                                {
+                                                    progress.Error(mod, "Error - Error while processing " + mod.config.name +
+                                                        " the copy needs to have a different name than the parent (use @name = xxx)");
+                                                }
+                                                break;
+
+                                            case Command.Delete:
+                                                progress.ApplyingDelete(url, mod);
+                                                url.parent.configs.Remove(url);
+                                                break;
+
+                                            case Command.Replace:
+
+                                                // TODO: do something sensible here.
+                                                break;
+
+                                            case Command.Create:
+
+                                                // TODO: something similar to above
+                                                break;
+                                        }
+                                        // When this special node is found then try to apply the patch once more on the same NODE
+                                        if (mod.config.HasNode("MM_PATCH_LOOP"))
+                                        {
+                                            logger.Info("Looping on " + mod.SafeUrl() + " to " + url.SafeUrl());
+                                            loop = true;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        loop = false;
+                                    }
+                                } while (loop);
+
+                            }
                         }
                     }
                 }

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -307,7 +307,7 @@ namespace ModuleManager
 
                 #endregion Applying patches
 
-                #region Logging
+                #region Saving Cache
 
                 if (progress.ErrorCount > 0 || progress.ExceptionCount > 0)
                 {
@@ -337,7 +337,9 @@ namespace ModuleManager
                     yield return null;
                     CreateCache();
                 }
-                
+
+                #endregion Saving Cache
+
                 SaveModdedTechTree();
                 SaveModdedPhysics();
             }
@@ -352,8 +354,6 @@ namespace ModuleManager
             StatusUpdate();
 
             logger.Info(status + "\n" + errors);
-
-                #endregion Logging
 
 #if DEBUG
             RunTestCases();

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -802,7 +802,7 @@ namespace ModuleManager
                         }
 
                         ConfigNode copy = new ConfigNode(type);
-                        ShallowCopy(currentMod.config, copy);
+                        copy.ShallowCopyFrom(currentMod.config);
                         currentMod = new UrlDir.UrlConfig(currentMod.parent, copy);
                         mod.parent.configs.Add(currentMod);
                     }
@@ -889,7 +889,7 @@ namespace ModuleManager
             }
 
             if (needsCopy)
-                ShallowCopy(copy, original);
+                original.ShallowCopyFrom(copy);
         }
 
         /// <summary>
@@ -2302,15 +2302,6 @@ namespace ModuleManager
                 return;
             }
             newNode.AddValue(name, value);
-        }
-
-        private static void ShallowCopy(ConfigNode from, ConfigNode to)
-        {
-            to.ClearData();
-            foreach (ConfigNode.Value value in from.values)
-                to.values.Add(value);
-            foreach (ConfigNode node in from.nodes)
-                to.nodes.Add(node);
         }
 
         private string PrettyConfig(UrlDir.UrlConfig config)

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -301,7 +301,7 @@ namespace ModuleManager
                 yield return StartCoroutine(ApplyPatch(":FIRST", patchList.firstPatches));
 
                 // any node without a :pass
-                yield return StartCoroutine(ApplyPatch(":LEGACY", patchList.legacyPatches));
+                yield return StartCoroutine(ApplyPatch(":LEGACY (default)", patchList.legacyPatches));
 
                 foreach (PatchList.ModPass pass in patchList.modPasses)
                 {
@@ -962,7 +962,7 @@ namespace ModuleManager
         public IEnumerator ApplyPatch(string Stage, IEnumerable<UrlDir.UrlConfig> patches)
         {
             StatusUpdate();
-            logger.Info(Stage + (Stage == ":LEGACY" ? " (default) pass" : " pass"));
+            logger.Info(Stage +  " pass");
             yield return null;
 
             activity = "ModuleManager " + Stage;

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -647,7 +647,6 @@ namespace ModuleManager
                 node.AddValue("name", config.name);
                 node.AddValue("type", config.type);
                 node.AddValue("parentUrl", config.parent.url);
-                node.AddValue("url", config.url);
                 node.AddNode(config.config);
             }
 
@@ -746,7 +745,6 @@ namespace ModuleManager
                 string name = node.GetValue("name");
                 string type = node.GetValue("type");
                 string parentUrl = node.GetValue("parentUrl");
-                string url = node.GetValue("url");
 
                 UrlDir.UrlFile parent = GameDatabase.Instance.root.AllConfigFiles.FirstOrDefault(f => f.url == parentUrl);
                 if (parent != null)

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -36,6 +36,8 @@
     <Compile Include="Cats\CatMover.cs" />
     <Compile Include="Cats\CatOrbiter.cs" />
     <Compile Include="Collections\ImmutableStack.cs" />
+    <Compile Include="Command.cs" />
+    <Compile Include="CommandParser.cs" />
     <Compile Include="Extensions\NodeStackExtensions.cs" />
     <Compile Include="IPatchProgress.cs" />
     <Compile Include="Logging\IBasicLogger.cs" />

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -47,6 +47,7 @@
     <Compile Include="MMPatchLoader.cs" />
     <Compile Include="ModuleManager.cs" />
     <Compile Include="PatchContext.cs" />
+    <Compile Include="PatchExtractor.cs" />
     <Compile Include="PatchList.cs" />
     <Compile Include="PatchProgress.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Cats\CatManager.cs" />
     <Compile Include="Cats\CatMover.cs" />
     <Compile Include="Cats\CatOrbiter.cs" />
+    <Compile Include="Collections\ArrayEnumerator.cs" />
     <Compile Include="Collections\ImmutableStack.cs" />
     <Compile Include="Command.cs" />
     <Compile Include="CommandParser.cs" />

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -41,6 +41,7 @@
     <Compile Include="CommandParser.cs" />
     <Compile Include="Extensions\ConfigNodeExtensions.cs" />
     <Compile Include="Extensions\NodeStackExtensions.cs" />
+    <Compile Include="Extensions\UrlConfigExtensions.cs" />
     <Compile Include="IPatchProgress.cs" />
     <Compile Include="Logging\IBasicLogger.cs" />
     <Compile Include="Logging\ModLogger.cs" />

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -41,6 +41,7 @@
     <Compile Include="CommandParser.cs" />
     <Compile Include="Extensions\ConfigNodeExtensions.cs" />
     <Compile Include="Extensions\NodeStackExtensions.cs" />
+    <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\UrlConfigExtensions.cs" />
     <Compile Include="IPatchProgress.cs" />
     <Compile Include="Logging\IBasicLogger.cs" />

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -47,6 +47,7 @@
     <Compile Include="MMPatchLoader.cs" />
     <Compile Include="ModuleManager.cs" />
     <Compile Include="PatchContext.cs" />
+    <Compile Include="PatchList.cs" />
     <Compile Include="PatchProgress.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs" />

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Collections\ImmutableStack.cs" />
     <Compile Include="Command.cs" />
     <Compile Include="CommandParser.cs" />
+    <Compile Include="Extensions\ConfigNodeExtensions.cs" />
     <Compile Include="Extensions\NodeStackExtensions.cs" />
     <Compile Include="IPatchProgress.cs" />
     <Compile Include="Logging\IBasicLogger.cs" />

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -19,6 +19,7 @@ namespace ModuleManager
         {
             PatchList list = new PatchList(modList);
 
+            // Have to convert to an array because we will be removing patches
             foreach (UrlDir.UrlConfig url in databaseRoot.AllConfigs.ToArray())
             {
                 try

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using ModuleManager.Extensions;
+
+namespace ModuleManager
+{
+    public static class PatchExtractor
+    {
+        private static readonly Regex firstRegex = new Regex(@":FIRST", RegexOptions.IgnoreCase);
+        private static readonly Regex finalRegex = new Regex(@":FINAL", RegexOptions.IgnoreCase);
+        private static readonly Regex beforeRegex = new Regex(@":BEFORE\[([^\[\]]+)\]", RegexOptions.IgnoreCase);
+        private static readonly Regex forRegex = new Regex(@":FOR\[([^\[\]]+)\]", RegexOptions.IgnoreCase);
+        private static readonly Regex afterRegex = new Regex(@":AFTER\[([^\[\]]+)\]", RegexOptions.IgnoreCase);
+
+        public static PatchList SortAndExtractPatches(UrlDir databaseRoot, IEnumerable<string> modList, IPatchProgress progress)
+        {
+            PatchList list = new PatchList(modList);
+
+            foreach (UrlDir.UrlConfig url in databaseRoot.AllConfigs.ToArray())
+            {
+                try
+                {
+                    Command command = CommandParser.Parse(url.type, out _);;
+
+                    Match firstMatch = firstRegex.Match(url.type);
+                    Match finalMatch = finalRegex.Match(url.type);
+                    Match beforeMatch = beforeRegex.Match(url.type);
+                    Match forMatch = forRegex.Match(url.type);
+                    Match afterMatch = afterRegex.Match(url.type);
+
+                    int matchCount = 0;
+
+                    if (firstMatch.Success) matchCount++;
+                    if (finalMatch.Success) matchCount++;
+                    if (beforeMatch.Success) matchCount++;
+                    if (forMatch.Success) matchCount++;
+                    if (afterMatch.Success) matchCount++;
+
+                    if (firstMatch.NextMatch().Success) matchCount++;
+                    if (finalMatch.NextMatch().Success) matchCount++;
+                    if (beforeMatch.NextMatch().Success) matchCount++;
+                    if (forMatch.NextMatch().Success) matchCount++;
+                    if (afterMatch.NextMatch().Success) matchCount++;
+
+                    bool error = false;
+
+                    if (command == Command.Insert && matchCount > 0)
+                    {
+                        progress.Error(url, $"Error - pass specifier detected on an insert node (not a patch): {url.parent.url}/{url.type}");
+                        error = true;
+                    }
+                    if (matchCount > 1)
+                    {
+                        progress.Error(url, $"Error - more than one pass specifier on a node: {url.parent.url}/{url.type}");
+                        error = true;
+                    }
+                    if (error)
+                    {
+                        url.parent.configs.Remove(url);
+                        continue;
+                    }
+
+                    if (command == Command.Insert) continue;
+
+                    url.parent.configs.Remove(url);
+
+                    Match theMatch = null;
+                    List<UrlDir.UrlConfig> thePass = null;
+                    bool modNotFound = false;
+
+                    if (firstMatch.Success)
+                    {
+                        theMatch = firstMatch;
+                        thePass = list.firstPatches;
+                    }
+                    else if (finalMatch.Success)
+                    {
+                        theMatch = finalMatch;
+                        thePass = list.finalPatches;
+                    }
+                    else if (beforeMatch.Success)
+                    {
+                        if (CheckMod(beforeMatch, list.modPasses, out string theMod))
+                        {
+                            theMatch = beforeMatch;
+                            thePass = list.modPasses[theMod].beforePatches;
+                        }
+                        else
+                        {
+                            modNotFound = true;
+                        }
+                    }
+                    else if (forMatch.Success)
+                    {
+                        if (CheckMod(forMatch, list.modPasses, out string theMod))
+                        {
+                            theMatch = forMatch;
+                            thePass = list.modPasses[theMod].forPatches;
+                        }
+                        else
+                        {
+                            modNotFound = true;
+                        }
+                    }
+                    else if (afterMatch.Success)
+                    {
+                        if (CheckMod(afterMatch, list.modPasses, out string theMod))
+                        {
+                            theMatch = afterMatch;
+                            thePass = list.modPasses[theMod].afterPatches;
+                        }
+                        else
+                        {
+                            modNotFound = true;
+                        }
+                    }
+                    else
+                    {
+                        thePass = list.legacyPatches;
+                    }
+
+                    if (modNotFound) continue;
+
+                    UrlDir.UrlConfig newUrl = url;
+                    if (theMatch != null)
+                    {
+                        string newName = url.type.Remove(theMatch.Index, theMatch.Length);
+                        ConfigNode newNode = new ConfigNode(newName) { id = url.config.id };
+                        newNode.ShallowCopyFrom(url.config);
+                        newUrl = new UrlDir.UrlConfig(url.parent, newNode);
+                    }
+
+                    thePass.Add(newUrl);
+                }
+                catch(Exception e)
+                {
+                    progress.Exception(url, $"Exception while parsing pass for config: {url.parent.url}/{url.type}", e);
+                }
+            }
+
+            return list;
+        }
+
+        private static bool CheckMod(Match match, PatchList.ModPassCollection modPasses, out string theMod)
+        {
+            theMod = match.Groups[1].Value.Trim().ToLower();
+            return modPasses.HasMod(theMod);
+        }
+    }
+}

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -11,9 +11,9 @@ namespace ModuleManager
     {
         private static readonly Regex firstRegex = new Regex(@":FIRST", RegexOptions.IgnoreCase);
         private static readonly Regex finalRegex = new Regex(@":FINAL", RegexOptions.IgnoreCase);
-        private static readonly Regex beforeRegex = new Regex(@":BEFORE\[([^\[\]]+)\]", RegexOptions.IgnoreCase);
-        private static readonly Regex forRegex = new Regex(@":FOR\[([^\[\]]+)\]", RegexOptions.IgnoreCase);
-        private static readonly Regex afterRegex = new Regex(@":AFTER\[([^\[\]]+)\]", RegexOptions.IgnoreCase);
+        private static readonly Regex beforeRegex = new Regex(@":BEFORE(?:\[([^\[\]]+)\])?", RegexOptions.IgnoreCase);
+        private static readonly Regex forRegex = new Regex(@":FOR(?:\[([^\[\]]+)\])?", RegexOptions.IgnoreCase);
+        private static readonly Regex afterRegex = new Regex(@":AFTER(?:\[([^\[\]]+)\])?", RegexOptions.IgnoreCase);
 
         public static PatchList SortAndExtractPatches(UrlDir databaseRoot, IEnumerable<string> modList, IPatchProgress progress)
         {
@@ -62,6 +62,21 @@ namespace ModuleManager
                     if (matchCount > 1)
                     {
                         progress.Error(url, $"Error - more than one pass specifier on a node: {url.SafeUrl()}");
+                        error = true;
+                    }
+                    if (beforeMatch.Success && !beforeMatch.Groups[1].Success)
+                    {
+                        progress.Error(url, "Error - malformed :BEFORE patch specifier detected: " + url.SafeUrl());
+                        error = true;
+                    }
+                    if (forMatch.Success && !forMatch.Groups[1].Success)
+                    {
+                        progress.Error(url, "Error - malformed :FOR patch specifier detected: " + url.SafeUrl());
+                        error = true;
+                    }
+                    if (afterMatch.Success && !afterMatch.Groups[1].Success)
+                    {
+                        progress.Error(url, "Error - malformed :AFTER patch specifier detected: " + url.SafeUrl());
                         error = true;
                     }
                     if (error)

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -59,6 +59,32 @@ namespace ModuleManager
                         progress.Error(url, $"Error - pass specifier detected on an insert node (not a patch): {url.SafeUrl()}");
                         error = true;
                     }
+                    else if (command == Command.Replace)
+                    {
+                        progress.Error(url, $"Error - replace command (%) is not valid on a root node: {url.SafeUrl()}");
+                        error = true;
+                    }
+                    else if (command == Command.Create)
+                    {
+                        progress.Error(url, $"Error - create command (&) is not valid on a root node: {url.SafeUrl()}");
+                        error = true;
+                    }
+                    else if (command == Command.Rename)
+                    {
+                        progress.Error(url, $"Error - rename command (|) is not valid on a root node: {url.SafeUrl()}");
+                        error = true;
+                    }
+                    else if (command == Command.Paste)
+                    {
+                        progress.Error(url, $"Error - paste command (#) is not valid on a root node: {url.SafeUrl()}");
+                        error = true;
+                    }
+                    else if (command == Command.Special)
+                    {
+                        progress.Error(url, $"Error - special command (*) is not valid on a root node: {url.SafeUrl()}");
+                        error = true;
+                    }
+
                     if (matchCount > 1)
                     {
                         progress.Error(url, $"Error - more than one pass specifier on a node: {url.SafeUrl()}");

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -91,6 +91,7 @@ namespace ModuleManager
                         else
                         {
                             modNotFound = true;
+                            progress.NeedsUnsatisfiedBefore(url);
                         }
                     }
                     else if (forMatch.Success)
@@ -103,6 +104,7 @@ namespace ModuleManager
                         else
                         {
                             modNotFound = true;
+                            progress.NeedsUnsatisfiedFor(url);
                         }
                     }
                     else if (afterMatch.Success)
@@ -115,6 +117,7 @@ namespace ModuleManager
                         else
                         {
                             modNotFound = true;
+                            progress.NeedsUnsatisfiedAfter(url);
                         }
                     }
                     else

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -23,6 +23,13 @@ namespace ModuleManager
             {
                 try
                 {
+                    if (!url.type.IsBracketBalanced())
+                    {
+                        progress.Error(url, "Error - node name does not have balanced brackets (or a space - if so replace with ?):\n" + url.SafeUrl());
+                        url.parent.configs.Remove(url);
+                        continue;
+                    }
+
                     Command command = CommandParser.Parse(url.type, out _);;
 
                     Match firstMatch = firstRegex.Match(url.type);

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using ModuleManager.Extensions;
 

--- a/ModuleManager/PatchExtractor.cs
+++ b/ModuleManager/PatchExtractor.cs
@@ -49,12 +49,12 @@ namespace ModuleManager
 
                     if (command == Command.Insert && matchCount > 0)
                     {
-                        progress.Error(url, $"Error - pass specifier detected on an insert node (not a patch): {url.parent.url}/{url.type}");
+                        progress.Error(url, $"Error - pass specifier detected on an insert node (not a patch): {url.SafeUrl()}");
                         error = true;
                     }
                     if (matchCount > 1)
                     {
-                        progress.Error(url, $"Error - more than one pass specifier on a node: {url.parent.url}/{url.type}");
+                        progress.Error(url, $"Error - more than one pass specifier on a node: {url.SafeUrl()}");
                         error = true;
                     }
                     if (error)
@@ -137,7 +137,7 @@ namespace ModuleManager
                 }
                 catch(Exception e)
                 {
-                    progress.Exception(url, $"Exception while parsing pass for config: {url.parent.url}/{url.type}", e);
+                    progress.Exception(url, $"Exception while parsing pass for config: {url.SafeUrl()}", e);
                 }
             }
 

--- a/ModuleManager/PatchList.cs
+++ b/ModuleManager/PatchList.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using ModuleManager.Collections;
+
+namespace ModuleManager
+{
+    public class PatchList
+    {
+        public class ModPass
+        {
+            public readonly List<UrlDir.UrlConfig> beforePatches = new List<UrlDir.UrlConfig>(0);
+            public readonly List<UrlDir.UrlConfig> forPatches = new List<UrlDir.UrlConfig>(0);
+            public readonly List<UrlDir.UrlConfig> afterPatches = new List<UrlDir.UrlConfig>(0);
+
+            public readonly string name;
+
+            public ModPass(string name)
+            {
+                this.name = name;
+            }
+        }
+
+        public class ModPassCollection : IEnumerable<ModPass>
+        {
+            private readonly ModPass[] passesArray;
+            private readonly Dictionary<string, ModPass> passesDict;
+
+            public ModPassCollection(IEnumerable<string> modList)
+            {
+                int count = modList.Count();
+                passesArray = new ModPass[count];
+                passesDict = new Dictionary<string, ModPass>(count);
+
+                int i = 0;
+                foreach (string mod in modList)
+                {
+                    ModPass pass = new ModPass(mod);
+                    passesArray[i] = pass;
+                    passesDict.Add(mod, pass);
+                    i++;
+                }
+            }
+
+            public ModPass this[string name] => passesDict[name];
+
+            public bool HasMod(string name) => passesDict.ContainsKey(name);
+
+            public ArrayEnumerator<ModPass> GetEnumerator() => new ArrayEnumerator<ModPass>(passesArray);
+            IEnumerator<ModPass> IEnumerable<ModPass>.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public readonly List<UrlDir.UrlConfig> firstPatches = new List<UrlDir.UrlConfig>();
+        public readonly List<UrlDir.UrlConfig> legacyPatches = new List<UrlDir.UrlConfig>();
+        public readonly List<UrlDir.UrlConfig> finalPatches = new List<UrlDir.UrlConfig>();
+
+        public readonly ModPassCollection modPasses;
+
+        public PatchList(IEnumerable<string> modList)
+        {
+            modPasses = new ModPassCollection(modList);
+        }
+    }
+}

--- a/ModuleManager/PatchList.cs
+++ b/ModuleManager/PatchList.cs
@@ -38,14 +38,14 @@ namespace ModuleManager
                 {
                     ModPass pass = new ModPass(mod);
                     passesArray[i] = pass;
-                    passesDict.Add(mod, pass);
+                    passesDict.Add(mod.ToLowerInvariant(), pass);
                     i++;
                 }
             }
 
-            public ModPass this[string name] => passesDict[name];
+            public ModPass this[string name] => passesDict[name.ToLowerInvariant()];
 
-            public bool HasMod(string name) => passesDict.ContainsKey(name);
+            public bool HasMod(string name) => passesDict.ContainsKey(name.ToLowerInvariant());
 
             public ArrayEnumerator<ModPass> GetEnumerator() => new ArrayEnumerator<ModPass>(passesArray);
             IEnumerator<ModPass> IEnumerable<ModPass>.GetEnumerator() => GetEnumerator();

--- a/ModuleManager/PatchProgress.cs
+++ b/ModuleManager/PatchProgress.cs
@@ -88,6 +88,27 @@ namespace ModuleManager
             NeedsUnsatisfiedCount += 1;
         }
 
+        public void NeedsUnsatisfiedBefore(UrlDir.UrlConfig url)
+        {
+            logger.Info($"Deleting root node in file {url.parent.url} node: {url.type} as it can't satisfy its BEFORE");
+            NeedsUnsatisfiedCount += 1;
+            NeedsUnsatisfiedRootCount += 1;
+        }
+
+        public void NeedsUnsatisfiedFor(UrlDir.UrlConfig url)
+        {
+            logger.Warning($"Deleting root node in file {url.parent.url} node: {url.type} as it can't satisfy its FOR (this shouldn't happen)");
+            NeedsUnsatisfiedCount += 1;
+            NeedsUnsatisfiedRootCount += 1;
+        }
+
+        public void NeedsUnsatisfiedAfter(UrlDir.UrlConfig url)
+        {
+            logger.Info($"Deleting root node in file {url.parent.url} node: {url.type} as it can't satisfy its AFTER");
+            NeedsUnsatisfiedCount += 1;
+            NeedsUnsatisfiedRootCount += 1;
+        }
+
         public void Error(UrlDir.UrlConfig url, string message)
         {
             ErrorCount += 1;

--- a/ModuleManager/PatchProgress.cs
+++ b/ModuleManager/PatchProgress.cs
@@ -48,19 +48,19 @@ namespace ModuleManager
 
         public void ApplyingUpdate(UrlDir.UrlConfig original, UrlDir.UrlConfig patch)
         {
-            logger.Info($"Applying update {patch.url} to {original.url}");
+            logger.Info($"Applying update {patch.SafeUrl()} to {original.SafeUrl()}");
             PatchedNodeCount += 1;
         }
 
         public void ApplyingCopy(UrlDir.UrlConfig original, UrlDir.UrlConfig patch)
         {
-            logger.Info($"Applying copy {patch.url} to {original.url}");
+            logger.Info($"Applying copy {patch.SafeUrl()} to {original.SafeUrl()}");
             PatchedNodeCount += 1;
         }
 
         public void ApplyingDelete(UrlDir.UrlConfig original, UrlDir.UrlConfig patch)
         {
-            logger.Info($"Applying delete {patch.url} to {original.url}");
+            logger.Info($"Applying delete {patch.SafeUrl()} to {original.SafeUrl()}");
             PatchedNodeCount += 1;
         }
 

--- a/ModuleManagerTests/Collections/ArrayEnumeratorTest.cs
+++ b/ModuleManagerTests/Collections/ArrayEnumeratorTest.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using ModuleManager.Collections;
+
+namespace ModuleManagerTests.Collections
+{
+    public class ArrayEnumeratorTest
+    {
+        [Fact]
+        public void TestArrayEnumerator()
+        {
+            string[] arr = { "abc", "def", "ghi" };
+
+            IEnumerator<string> enumerator = new ArrayEnumerator<string>(arr);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("abc", enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("def", enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("ghi", enumerator.Current);
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void TestArrayEnumerator__Reset()
+        {
+            string[] arr = { "abc", "def" };
+
+            IEnumerator<string> enumerator = new ArrayEnumerator<string>(arr);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("abc", enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("def", enumerator.Current);
+            Assert.False(enumerator.MoveNext());
+
+            enumerator.Reset();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("abc", enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("def", enumerator.Current);
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void TestArrayEnumerator__Empty()
+        {
+            string[] arr = new string[0];
+            IEnumerator<string> enumerator = new ArrayEnumerator<string>(arr);
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+}

--- a/ModuleManagerTests/CommandParserTest.cs
+++ b/ModuleManagerTests/CommandParserTest.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using ModuleManager;
+
+namespace ModuleManagerTests
+{
+    public class CommandParserTest
+    {
+        [Fact]
+        public void TestParse__Insert()
+        {
+            Assert.Equal(Command.Insert, CommandParser.Parse("PART", out string newName));
+            Assert.Equal("PART", newName);
+        }
+
+        [Fact]
+        public void TestParse__Delete()
+        {
+            Assert.Equal(Command.Delete, CommandParser.Parse("!PART", out string newName1));
+            Assert.Equal("PART", newName1);
+            Assert.Equal(Command.Delete, CommandParser.Parse("-PART", out string newName2));
+            Assert.Equal("PART", newName2);
+        }
+
+        [Fact]
+        public void TestParse__Edit()
+        {
+            Assert.Equal(Command.Edit, CommandParser.Parse("@PART", out string newName));
+            Assert.Equal("PART", newName);
+        }
+
+        [Fact]
+        public void TestParse__Replace()
+        {
+            Assert.Equal(Command.Replace, CommandParser.Parse("%PART", out string newName));
+            Assert.Equal("PART", newName);
+        }
+
+        [Fact]
+        public void TestParse__Copy()
+        {
+            Assert.Equal(Command.Copy, CommandParser.Parse("+PART", out string newName1));
+            Assert.Equal("PART", newName1);
+            Assert.Equal(Command.Copy, CommandParser.Parse("$PART", out string newName2));
+            Assert.Equal("PART", newName2);
+        }
+
+        [Fact]
+        public void TestParse__Rename()
+        {
+            Assert.Equal(Command.Rename, CommandParser.Parse("|PART", out string newName));
+            Assert.Equal("PART", newName); ;
+        }
+
+        [Fact]
+        public void TestParse__Paste()
+        {
+            Assert.Equal(Command.Paste, CommandParser.Parse("#PART", out string newName));
+            Assert.Equal("PART", newName);
+        }
+
+        [Fact]
+        public void TestParse__Special()
+        {
+            Assert.Equal(Command.Special, CommandParser.Parse("*PART", out string newName));
+            Assert.Equal("PART", newName);
+        }
+
+        [Fact]
+        public void TestParse__Special__Chained()
+        {
+            Assert.Equal(Command.Special, CommandParser.Parse("*@PART", out string newName));
+            Assert.Equal("@PART", newName);
+        }
+
+        [Fact]
+        public void TestParse__Create()
+        {
+            Assert.Equal(Command.Create, CommandParser.Parse("&PART", out string newName));
+            Assert.Equal("PART", newName);
+        }
+    }
+}

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Xunit;
 using TestUtils;
 using ModuleManager.Extensions;

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -83,5 +83,67 @@ namespace ModuleManagerTests.Extensions
             Assert.Equal(0, innerNode2.nodes[0].values.Count);
             Assert.Equal(0, innerNode2.nodes[0].nodes.Count);
         }
+
+        [Fact]
+        public void TestDeepCopy()
+        {
+            ConfigNode fromNode = new TestConfigNode("SOME_NODE")
+            {
+                { "abc", "def" },
+                { "ghi", "jkl" },
+                new TestConfigNode("INNER_NODE_1")
+                {
+                    { "mno", "pqr" },
+                    new TestConfigNode("INNER_INNER_NODE_1"),
+                },
+                new TestConfigNode("INNER_NODE_2")
+                {
+                    { "stu", "vwx" },
+                    new TestConfigNode("INNER_INNER_NODE_2"),
+                },
+            };
+            
+            ConfigNode toNode = fromNode.DeepCopy();
+            
+            Assert.Equal("SOME_NODE", toNode.name);
+            
+            Assert.Equal(2, toNode.values.Count);
+            
+            Assert.NotSame(fromNode.values[0], toNode.values[0]);
+            Assert.Equal("abc", toNode.values[0].name);
+            Assert.Equal("def", toNode.values[0].value);
+            
+            Assert.NotSame(fromNode.values[1], toNode.values[1]);
+            Assert.Equal("ghi", toNode.values[1].name);
+            Assert.Equal("jkl", toNode.values[1].value);
+            
+            Assert.Equal(2, toNode.nodes.Count);
+
+            ConfigNode innerNode1 = toNode.nodes[0];
+            Assert.NotSame(fromNode.nodes[0], innerNode1);
+            Assert.Equal("INNER_NODE_1", innerNode1.name);
+            Assert.Equal(1, innerNode1.values.Count);
+            Assert.NotSame(fromNode.nodes[0].values[0], innerNode1.values[0]);
+            Assert.Equal("mno", innerNode1.values[0].name);
+            Assert.Equal("pqr", innerNode1.values[0].value);
+            Assert.Equal(1, toNode.nodes[0].nodes.Count);
+            Assert.NotSame(fromNode.nodes[0].nodes[0], innerNode1.nodes[0]);
+            Assert.Equal("INNER_INNER_NODE_1", innerNode1.nodes[0].name);
+            Assert.Equal(0, innerNode1.nodes[0].values.Count);
+            Assert.Equal(0, innerNode1.nodes[0].nodes.Count);
+
+            ConfigNode innerNode2 = toNode.nodes[1];
+            Assert.NotSame(fromNode.nodes[1], innerNode2);
+            Assert.Equal("INNER_NODE_2", innerNode2.name);
+            Assert.Equal(1, innerNode2.values.Count);
+            Assert.NotSame(fromNode.nodes[1].values[0], innerNode2.values[0]);
+            Assert.Equal("stu", innerNode2.values[0].name);
+            Assert.Equal("vwx", innerNode2.values[0].value);
+            Assert.Equal(1, innerNode2.nodes.Count);
+            Assert.NotSame(fromNode.nodes[1].nodes[0], innerNode2.nodes[0]);
+            Assert.Equal("INNER_INNER_NODE_2", innerNode2.nodes[0].name);
+            Assert.Equal(0, innerNode2.nodes[0].values.Count);
+            Assert.Equal(0, innerNode2.nodes[0].nodes.Count);
+        }
     }
 }

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using TestUtils;
+using ModuleManager.Extensions;
+
+namespace ModuleManagerTests.Extensions
+{
+    public class ConfigNodeExtensionsTest
+    {
+        public void TestShallowCopyFrom()
+        {
+            ConfigNode fromNode = new TestConfigNode("SOME_NODE")
+            {
+                { "abc", "def" },
+                { "ghi", "jkl" },
+                new TestConfigNode("INNER_NODE_1")
+                {
+                    { "mno", "pqr" },
+                    new TestConfigNode("INNER_INNER_NODE_1"),
+                },
+                new TestConfigNode("INNER_NODE_2")
+                {
+                    { "stu", "vwx" },
+                    new TestConfigNode("INNER_INNER_NODE_2"),
+                },
+            };
+
+            ConfigNode.Value value1 = fromNode.values[0];
+            ConfigNode.Value value2 = fromNode.values[1];
+
+            ConfigNode innerNode1 = fromNode.nodes[0];
+            ConfigNode innerNode2 = fromNode.nodes[1];
+
+            ConfigNode toNode = new TestConfigNode("SOME_OTHER_NODE")
+            {
+                { "value", "will be removed" },
+                new TestConfigNode("NODE_WILL_BE_REMOVED"),
+            };
+
+            toNode.ShallowCopyFrom(fromNode);
+
+            Assert.Equal("SOME_NODE", fromNode.name);
+            Assert.Equal("SOME_OTHER_NODE", toNode.name);
+
+            Assert.Equal(2, fromNode.values.Count);
+            Assert.Equal(2, toNode.values.Count);
+
+            Assert.Same(value1, fromNode.values[0]);
+            Assert.Same(value1, toNode.values[0]);
+            Assert.Equal("abc", value1.name);
+            Assert.Equal("def", value1.value);
+
+            Assert.Same(value2, fromNode.values[1]);
+            Assert.Same(value2, toNode.values[1]);
+            Assert.Equal("ghi", value2.name);
+            Assert.Equal("jkl", value2.value);
+
+            Assert.Equal(2, fromNode.nodes.Count);
+            Assert.Equal(2, toNode.nodes.Count);
+
+            Assert.Same(innerNode1, fromNode.nodes[0]);
+            Assert.Same(innerNode1, toNode.nodes[0]);
+            Assert.Equal("INNER_NODE_1", innerNode1.name);
+            Assert.Equal(1, innerNode1.values.Count);
+            Assert.Equal("mno", innerNode1.values[0].name);
+            Assert.Equal("pqr", innerNode1.values[0].value);
+            Assert.Equal(1, innerNode1.nodes.Count);
+            Assert.Equal("INNER_INNER_NODE_1", innerNode1.nodes[0].name);
+            Assert.Equal(0, innerNode1.nodes[0].values.Count);
+            Assert.Equal(0, innerNode1.nodes[0].nodes.Count);
+
+            Assert.Same(innerNode2, fromNode.nodes[1]);
+            Assert.Same(innerNode2, toNode.nodes[1]);
+            Assert.Equal("INNER_NODE_2", innerNode2.name);
+            Assert.Equal(1, innerNode2.values.Count);
+            Assert.Equal("stu", innerNode2.values[0].name);
+            Assert.Equal("vwx", innerNode2.values[0].value);
+            Assert.Equal(1, innerNode2.nodes.Count);
+            Assert.Equal("INNER_INNER_NODE_2", innerNode2.nodes[0].name);
+            Assert.Equal(0, innerNode2.nodes[0].values.Count);
+            Assert.Equal(0, innerNode2.nodes[0].nodes.Count);
+        }
+    }
+}

--- a/ModuleManagerTests/Extensions/StringExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/StringExtensionsTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using ModuleManager.Extensions;
+
+namespace ModuleManagerTests.Extensions
+{
+    public class StringExtensionsTest
+    {
+        [Fact]
+        public void TestIsBracketBalanced()
+        {
+            Assert.True("abc[def[ghi[jkl]mno[pqr]]stu]vwx".IsBracketBalanced());
+        }
+
+        [Fact]
+        public void TestIsBracketBalanced__NoBrackets()
+        {
+            Assert.True("she sells seashells by the seashore".IsBracketBalanced());
+        }
+
+        [Fact]
+        public void TestIsBracketBalanced__Unbalanced()
+        {
+            Assert.False("abc[def[ghi[jkl]mno[pqr]]stuvwx".IsBracketBalanced());
+            Assert.False("abcdef[ghi[jkl]mno[pqr]]stu]vwx".IsBracketBalanced());
+        }
+        [Fact]
+        public void TestIsBracketBalanced__BalancedButNegative()
+        {
+            Assert.False("abc]def[ghi".IsBracketBalanced());
+        }
+    }
+}

--- a/ModuleManagerTests/Extensions/UrlConfigExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/UrlConfigExtensionsTest.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using TestUtils;
+using ModuleManager.Extensions;
+
+namespace ModuleManagerTests.Extensions
+{
+    public class UrlConfigExtensionsTest
+    {
+        [Fact]
+        public void TestSafeUrl()
+        {
+            ConfigNode node = new TestConfigNode("SOME_NODE")
+            {
+                { "name", "this shouldn't show up" },
+            };
+            UrlDir.UrlConfig url = UrlBuilder.CreateConfig("abc/def", node);
+            Assert.Equal("abc/def/SOME_NODE", url.SafeUrl());
+        }
+
+        [Fact]
+        public void TestSafeUrl__Null()
+        {
+            UrlDir.UrlConfig url = null;
+            Assert.Equal("<null>", url.SafeUrl());
+        }
+
+        [Fact]
+        public void TestSafeUrl__NullParent()
+        {
+            UrlDir.UrlConfig url = new UrlDir.UrlConfig(null, new ConfigNode("SOME_NODE"));
+            Assert.Equal("SOME_NODE", url.SafeUrl());
+        }
+
+        [Fact]
+        public void TestSafeUrl__NullParent__NullName()
+        {
+            ConfigNode node = new ConfigNode
+            {
+                name = null
+            };
+            UrlDir.UrlConfig url = new UrlDir.UrlConfig(null, node);
+            Assert.Equal("<blank>", url.SafeUrl());
+        }
+
+        [Fact]
+        public void TestSafeUrl__NullParent__BlankName()
+        {
+            UrlDir.UrlConfig url = new UrlDir.UrlConfig(null, new ConfigNode(" "));
+            Assert.Equal("<blank>", url.SafeUrl());
+        }
+
+        [Fact]
+        public void TestSafeUrl__NullName()
+        {
+            ConfigNode node = new TestConfigNode()
+            {
+                { "name", "this shouldn't show up" },
+            };
+            node.name = null;
+            UrlDir.UrlConfig url = UrlBuilder.CreateConfig("abc/def", node);
+            Assert.Equal("abc/def/<blank>", url.SafeUrl());
+        }
+
+        [Fact]
+        public void TestSafeUrl__BlankName()
+        {
+            ConfigNode node = new TestConfigNode(" ")
+            {
+                { "name", "this shouldn't show up" },
+            };
+            UrlDir.UrlConfig url = UrlBuilder.CreateConfig("abc/def", node);
+            Assert.Equal("abc/def/<blank>", url.SafeUrl());
+        }
+    }
+}

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\UrlConfigExtensionsTest.cs" />
     <Compile Include="PatchListTest.cs" />
     <Compile Include="Collections\ArrayEnumeratorTest.cs" />
     <Compile Include="Collections\ImmutableStackTest.cs" />

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PatchListTest.cs" />
     <Compile Include="Collections\ArrayEnumeratorTest.cs" />
     <Compile Include="Collections\ImmutableStackTest.cs" />
     <Compile Include="CommandParserTest.cs" />

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Extensions\ConfigNodeExtensionsTest.cs" />
     <Compile Include="Extensions\NodeStackExtensionsTest.cs" />
     <Compile Include="Logging\ModLoggerTest.cs" />
+    <Compile Include="PatchExtractorTest.cs" />
     <Compile Include="PatchProgressTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\StringExtensionsTest.cs" />
     <Compile Include="Extensions\UrlConfigExtensionsTest.cs" />
     <Compile Include="PatchListTest.cs" />
     <Compile Include="Collections\ArrayEnumeratorTest.cs" />

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Collections\ArrayEnumeratorTest.cs" />
     <Compile Include="Collections\ImmutableStackTest.cs" />
     <Compile Include="CommandParserTest.cs" />
     <Compile Include="DummyTest.cs" />

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Collections\ImmutableStackTest.cs" />
+    <Compile Include="CommandParserTest.cs" />
     <Compile Include="DummyTest.cs" />
     <Compile Include="Extensions\NodeStackExtensionsTest.cs" />
     <Compile Include="Logging\ModLoggerTest.cs" />

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Collections\ImmutableStackTest.cs" />
     <Compile Include="CommandParserTest.cs" />
     <Compile Include="DummyTest.cs" />
+    <Compile Include="Extensions\ConfigNodeExtensionsTest.cs" />
     <Compile Include="Extensions\NodeStackExtensionsTest.cs" />
     <Compile Include="Logging\ModLoggerTest.cs" />
     <Compile Include="PatchProgressTest.cs" />

--- a/ModuleManagerTests/PatchExtractorTest.cs
+++ b/ModuleManagerTests/PatchExtractorTest.cs
@@ -197,6 +197,21 @@ namespace ModuleManagerTests
             AssertUrlCorrect("@NODE[foo]:HAS[#bar]", afterMod2Configs[1], currentPatches[1]);
             AssertUrlCorrect("@NADE",                afterMod2Configs[2], currentPatches[2]);
             AssertUrlCorrect("@NADE",                afterMod2Configs[3], currentPatches[3]);
+
+            progress.Received().NeedsUnsatisfiedBefore(beforeMod3Configs[0]);
+            progress.Received().NeedsUnsatisfiedBefore(beforeMod3Configs[1]);
+            progress.Received().NeedsUnsatisfiedBefore(beforeMod3Configs[2]);
+            progress.Received().NeedsUnsatisfiedBefore(beforeMod3Configs[3]);
+
+            progress.Received().NeedsUnsatisfiedFor(forMod3Configs[0]);
+            progress.Received().NeedsUnsatisfiedFor(forMod3Configs[1]);
+            progress.Received().NeedsUnsatisfiedFor(forMod3Configs[2]);
+            progress.Received().NeedsUnsatisfiedFor(forMod3Configs[3]);
+
+            progress.Received().NeedsUnsatisfiedAfter(afterMod3Configs[0]);
+            progress.Received().NeedsUnsatisfiedAfter(afterMod3Configs[1]);
+            progress.Received().NeedsUnsatisfiedAfter(afterMod3Configs[2]);
+            progress.Received().NeedsUnsatisfiedAfter(afterMod3Configs[3]);
         }
 
         [Fact]

--- a/ModuleManagerTests/PatchExtractorTest.cs
+++ b/ModuleManagerTests/PatchExtractorTest.cs
@@ -1,0 +1,315 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using NSubstitute;
+using TestUtils;
+using ModuleManager;
+
+namespace ModuleManagerTests
+{
+    public class PatchExtractorTest
+    {
+        private UrlDir root;
+        private UrlDir.UrlFile file;
+
+        private IPatchProgress progress;
+
+        public PatchExtractorTest()
+        {
+            root = UrlBuilder.CreateRoot();
+            file = UrlBuilder.CreateFile("abc/def.cfg", root);
+
+            progress = Substitute.For<IPatchProgress>();
+        }
+
+        [Fact]
+        public void TestSortAndExtractPatches()
+        {
+            UrlDir.UrlConfig[] insertConfigs =
+            {
+                CreateConfig("NODE"),
+                CreateConfig("NADE"),
+            };
+
+            UrlDir.UrlConfig[] legacyConfigs =
+            {
+                CreateConfig("@NODE"),
+                CreateConfig("@NADE[foo]:HAS[#bar]"),
+            };
+
+            UrlDir.UrlConfig[] firstConfigs =
+            {
+                CreateConfig("@NODE:FIRST"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:FIRST"),
+                CreateConfig("@NADE:First"),
+                CreateConfig("@NADE:first"),
+            };
+
+            UrlDir.UrlConfig[] finalConfigs =
+            {
+                CreateConfig("@NODE:FINAL"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:FINAL"),
+                CreateConfig("@NADE:Final"),
+                CreateConfig("@NADE:final"),
+            };
+
+            UrlDir.UrlConfig[] beforeMod1Configs =
+            {
+                CreateConfig("@NODE:BEFORE[mod1]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:BEFORE[mod1]"),
+                CreateConfig("@NADE:before[mod1]"),
+                CreateConfig("@NADE:BEFORE[MOD1]"),
+            };
+
+            UrlDir.UrlConfig[] forMod1Configs =
+            {
+                CreateConfig("@NODE:FOR[mod1]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:FOR[mod1]"),
+                CreateConfig("@NADE:for[mod1]"),
+                CreateConfig("@NADE:FOR[MOD1]"),
+            };
+
+            UrlDir.UrlConfig[] afterMod1Configs =
+            {
+                CreateConfig("@NODE:AFTER[mod1]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:AFTER[mod1]"),
+                CreateConfig("@NADE:after[mod1]"),
+                CreateConfig("@NADE:AFTER[MOD1]"),
+            };
+
+            UrlDir.UrlConfig[] beforeMod2Configs =
+            {
+                CreateConfig("@NODE:BEFORE[mod2]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:BEFORE[mod2]"),
+                CreateConfig("@NADE:before[mod2]"),
+                CreateConfig("@NADE:BEFORE[MOD2]"),
+            };
+
+            UrlDir.UrlConfig[] forMod2Configs =
+            {
+                CreateConfig("@NODE:FOR[mod2]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:FOR[mod2]"),
+                CreateConfig("@NADE:for[mod2]"),
+                CreateConfig("@NADE:FOR[MOD2]"),
+            };
+
+            UrlDir.UrlConfig[] afterMod2Configs =
+            {
+                CreateConfig("@NODE:AFTER[mod2]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:AFTER[mod2]"),
+                CreateConfig("@NADE:after[mod2]"),
+                CreateConfig("@NADE:AFTER[MOD2]"),
+            };
+
+            UrlDir.UrlConfig[] beforeMod3Configs =
+            {
+                CreateConfig("@NODE:BEFORE[mod3]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:BEFORE[mod3]"),
+                CreateConfig("@NADE:before[mod3]"),
+                CreateConfig("@NADE:BEFORE[MOD3]"),
+            };
+
+            UrlDir.UrlConfig[] forMod3Configs =
+            {
+                CreateConfig("@NODE:FOR[mod3]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:FOR[mod3]"),
+                CreateConfig("@NADE:for[mod3]"),
+                CreateConfig("@NADE:FOR[MOD3]"),
+            };
+
+            UrlDir.UrlConfig[] afterMod3Configs =
+            {
+                CreateConfig("@NODE:AFTER[mod3]"),
+                CreateConfig("@NODE[foo]:HAS[#bar]:AFTER[mod3]"),
+                CreateConfig("@NADE:after[mod3]"),
+                CreateConfig("@NADE:AFTER[MOD3]"),
+            };
+
+            string[] modList = { "mod1", "mod2" };
+            PatchList list = PatchExtractor.SortAndExtractPatches(root, modList, progress);
+
+            progress.DidNotReceiveWithAnyArgs().Error(null, null);
+            progress.DidNotReceiveWithAnyArgs().Exception(null, null);
+            progress.DidNotReceiveWithAnyArgs().Exception(null, null, null);
+
+            Assert.True(list.modPasses.HasMod("mod1"));
+            Assert.True(list.modPasses.HasMod("mod2"));
+            Assert.False(list.modPasses.HasMod("mod3"));
+
+            Assert.Equal(insertConfigs, root.AllConfigs);
+
+            Assert.Equal(legacyConfigs, list.legacyPatches);
+
+            List<UrlDir.UrlConfig> currentPatches;
+
+            currentPatches = list.firstPatches;
+            Assert.Equal(firstConfigs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                firstConfigs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", firstConfigs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                firstConfigs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                firstConfigs[3], currentPatches[3]);
+
+            currentPatches = list.finalPatches;
+            Assert.Equal(finalConfigs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                finalConfigs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", finalConfigs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                finalConfigs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                finalConfigs[3], currentPatches[3]);
+
+            currentPatches = list.modPasses["mod1"].beforePatches;
+            Assert.Equal(beforeMod1Configs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                beforeMod1Configs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", beforeMod1Configs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                beforeMod1Configs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                beforeMod1Configs[3], currentPatches[3]);
+
+            currentPatches = list.modPasses["mod1"].forPatches;
+            Assert.Equal(forMod1Configs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                forMod1Configs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", forMod1Configs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                forMod1Configs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                forMod1Configs[3], currentPatches[3]);
+
+            currentPatches = list.modPasses["mod1"].afterPatches;
+            Assert.Equal(afterMod1Configs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                afterMod1Configs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", afterMod1Configs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                afterMod1Configs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                afterMod1Configs[3], currentPatches[3]);
+
+            currentPatches = list.modPasses["mod2"].beforePatches;
+            Assert.Equal(beforeMod2Configs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                beforeMod2Configs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", beforeMod2Configs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                beforeMod2Configs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                beforeMod2Configs[3], currentPatches[3]);
+
+            currentPatches = list.modPasses["mod2"].forPatches;
+            Assert.Equal(forMod1Configs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                forMod2Configs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", forMod2Configs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                forMod2Configs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                forMod2Configs[3], currentPatches[3]);
+
+            currentPatches = list.modPasses["mod2"].afterPatches;
+            Assert.Equal(afterMod1Configs.Length, currentPatches.Count);
+            AssertUrlCorrect("@NODE",                afterMod2Configs[0], currentPatches[0]);
+            AssertUrlCorrect("@NODE[foo]:HAS[#bar]", afterMod2Configs[1], currentPatches[1]);
+            AssertUrlCorrect("@NADE",                afterMod2Configs[2], currentPatches[2]);
+            AssertUrlCorrect("@NADE",                afterMod2Configs[3], currentPatches[3]);
+        }
+
+        [Fact]
+        public void TestSortAndExtractPatches__InsertWithPass()
+        {
+            UrlDir.UrlConfig config1 = CreateConfig("NODE");
+            UrlDir.UrlConfig config2 = CreateConfig("NODE:FOR[mod1]");
+            UrlDir.UrlConfig config3 = CreateConfig("NODE:FOR[mod2]");
+            UrlDir.UrlConfig config4 = CreateConfig("NODE:FINAL");
+
+            string[] modList = { "mod1" };
+            PatchList list = PatchExtractor.SortAndExtractPatches(root, modList, progress);
+
+            Assert.Equal(new[] { config1 }, root.AllConfigs);
+
+            progress.Received().Error(config2, "Error - pass specifier detected on an insert node (not a patch): abc/def/NODE:FOR[mod1]");
+            progress.Received().Error(config3, "Error - pass specifier detected on an insert node (not a patch): abc/def/NODE:FOR[mod2]");
+            progress.Received().Error(config4, "Error - pass specifier detected on an insert node (not a patch): abc/def/NODE:FINAL");
+
+            Assert.Empty(list.firstPatches);
+            Assert.Empty(list.legacyPatches);
+            Assert.Empty(list.finalPatches);
+            Assert.Empty(list.modPasses["mod1"].beforePatches);
+            Assert.Empty(list.modPasses["mod1"].forPatches);
+            Assert.Empty(list.modPasses["mod1"].afterPatches);
+        }
+
+        [Fact]
+        public void TestSortAndExtractPatches__MoreThanOnePass()
+        {
+            UrlDir.UrlConfig config1 = CreateConfig("@NODE:FIRST");
+            UrlDir.UrlConfig config2 = CreateConfig("@NODE:FIRST:FIRST");
+            UrlDir.UrlConfig config3 = CreateConfig("@NODE:FIRST:FOR[mod1]");
+
+            string[] modList = { "mod1" };
+            PatchList list = PatchExtractor.SortAndExtractPatches(root, modList, progress);
+
+            Assert.Empty(root.AllConfigs);
+
+            progress.Received().Error(config2, "Error - more than one pass specifier on a node: abc/def/@NODE:FIRST:FIRST");
+            progress.Received().Error(config3, "Error - more than one pass specifier on a node: abc/def/@NODE:FIRST:FOR[mod1]");
+
+            Assert.Equal(1, list.firstPatches.Count);
+            AssertUrlCorrect("@NODE", config1, list.firstPatches[0]);
+            Assert.Empty(list.legacyPatches);
+            Assert.Empty(list.finalPatches);
+            Assert.Empty(list.modPasses["mod1"].beforePatches);
+            Assert.Empty(list.modPasses["mod1"].forPatches);
+            Assert.Empty(list.modPasses["mod1"].afterPatches);
+        }
+
+        [Fact]
+        public void TestSortAndExtractPatches__Exception()
+        {
+            Exception e = new Exception("an exception was thrown");
+            progress.WhenForAnyArgs(p => p.Error(null, null)).Throw(e);
+
+            UrlDir.UrlConfig config1 = CreateConfig("@NODE");
+            UrlDir.UrlConfig config2 = CreateConfig("@NODE:FIRST:FIRST");
+            UrlDir.UrlConfig config3 = CreateConfig("@NADE:FIRST");
+
+            string[] modList = { "mod1" };
+            PatchList list = PatchExtractor.SortAndExtractPatches(root, modList, progress);
+
+            progress.Received().Exception(config2, "Exception while parsing pass for config: abc/def/@NODE:FIRST:FIRST", e);
+
+            Assert.Equal(new[] { config1 }, list.legacyPatches);
+            Assert.Equal(1, list.firstPatches.Count);
+            AssertUrlCorrect("@NADE", config3, list.firstPatches[0]);
+        }
+
+        private UrlDir.UrlConfig CreateConfig(string name)
+        {
+            ConfigNode node = new TestConfigNode(name)
+            {
+                { "name", "snack" },
+                { "cheese", "gouda" },
+                { "bread", "sourdough" },
+                new ConfigNode("wine"),
+                new ConfigNode("fruit"),
+            };
+
+            node.id = "hungry?";
+
+            return UrlBuilder.CreateConfig(node, file);
+        }
+
+        private void AssertUrlCorrect(string expectedNodeName, UrlDir.UrlConfig originalUrl, UrlDir.UrlConfig observedUrl)
+        {
+            Assert.Equal(expectedNodeName, observedUrl.type);
+
+            ConfigNode originalNode = originalUrl.config;
+            ConfigNode observedNode = observedUrl.config;
+
+            Assert.Equal(expectedNodeName, observedNode.name);
+
+            if (originalNode.HasValue("name")) Assert.Equal(originalNode.GetValue("name"), observedUrl.name);
+
+            Assert.Same(originalUrl.parent, observedUrl.parent);
+
+            Assert.Equal(originalNode.id, observedNode.id);
+            Assert.Equal(originalNode.values.Count, observedNode.values.Count);
+            Assert.Equal(originalNode.nodes.Count, observedNode.nodes.Count);
+
+            for (int i = 0; i < originalNode.values.Count; i++)
+            {
+                Assert.Same(originalNode.values[i], observedNode.values[i]);
+            }
+
+            for (int i = 0; i < originalNode.nodes.Count; i++)
+            {
+                Assert.Same(originalNode.nodes[i], observedNode.nodes[i]);
+            }
+        }
+    }
+}

--- a/ModuleManagerTests/PatchListTest.cs
+++ b/ModuleManagerTests/PatchListTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using ModuleManager;
+
+namespace ModuleManagerTests
+{
+    public class PatchListTest
+    {
+        [Fact]
+        public void TestConstructor()
+        {
+            PatchList list = new PatchList(new string[0]);
+
+            Assert.NotNull(list.firstPatches);
+            Assert.NotNull(list.legacyPatches);
+            Assert.NotNull(list.finalPatches);
+            Assert.NotNull(list.modPasses);
+        }
+
+        [Fact]
+        public void TestModPasses__HasMod()
+        {
+            PatchList list = new PatchList(new[] { "mod1", "mod2" });
+
+            PatchList.ModPassCollection collection = list.modPasses;
+
+            Assert.True(collection.HasMod("mod1"));
+            Assert.True(collection.HasMod("mod2"));
+            Assert.False(collection.HasMod("mod3"));
+        }
+
+        [Fact]
+        public void TestModPasses__Accessor()
+        {
+            PatchList list = new PatchList(new[] { "mod1", "mod2" });
+
+            PatchList.ModPass pass1 = list.modPasses["mod1"];
+            Assert.NotNull(pass1);
+            Assert.Equal("mod1", pass1.name);
+            Assert.NotNull(pass1.beforePatches);
+            Assert.Equal(0, pass1.beforePatches.Capacity);
+            Assert.NotNull(pass1.forPatches);
+            Assert.Equal(0, pass1.forPatches.Capacity);
+            Assert.NotNull(pass1.afterPatches);
+            Assert.Equal(0, pass1.afterPatches.Capacity);
+
+            PatchList.ModPass pass2 = list.modPasses["mod2"];
+            Assert.NotNull(pass2);
+            Assert.Equal("mod2", pass2.name);
+            Assert.NotNull(pass2.beforePatches);
+            Assert.Equal(0, pass2.beforePatches.Capacity);
+            Assert.NotNull(pass2.forPatches);
+            Assert.Equal(0, pass2.forPatches.Capacity);
+            Assert.NotNull(pass2.afterPatches);
+            Assert.Equal(0, pass2.afterPatches.Capacity);
+
+            Assert.Throws<KeyNotFoundException>(delegate
+            {
+                PatchList.ModPass mod3 = list.modPasses["mod3"];
+            });
+        }
+
+        [Fact]
+        public void TestModPasses__Enumeration()
+        {
+            PatchList list = new PatchList(new[] { "mod1", "mod2" });
+
+            PatchList.ModPass[] passes = new PatchList.ModPass[] { list.modPasses["mod1"], list.modPasses["mod2"] };
+
+            Assert.Equal(passes, list.modPasses);
+        }
+    }
+}

--- a/ModuleManagerTests/PatchListTest.cs
+++ b/ModuleManagerTests/PatchListTest.cs
@@ -21,13 +21,25 @@ namespace ModuleManagerTests
         [Fact]
         public void TestModPasses__HasMod()
         {
-            PatchList list = new PatchList(new[] { "mod1", "mod2" });
+            PatchList list = new PatchList(new[] { "mod1", "Mod2", "MOD3" });
 
             PatchList.ModPassCollection collection = list.modPasses;
 
             Assert.True(collection.HasMod("mod1"));
+            Assert.True(collection.HasMod("Mod1"));
+            Assert.True(collection.HasMod("MOD1"));
+
             Assert.True(collection.HasMod("mod2"));
-            Assert.False(collection.HasMod("mod3"));
+            Assert.True(collection.HasMod("Mod2"));
+            Assert.True(collection.HasMod("MOD2"));
+
+            Assert.True(collection.HasMod("mod3"));
+            Assert.True(collection.HasMod("Mod3"));
+            Assert.True(collection.HasMod("MOD3"));
+
+            Assert.False(collection.HasMod("mod4"));
+            Assert.False(collection.HasMod("Mod4"));
+            Assert.False(collection.HasMod("MOD4"));
         }
 
         [Fact]

--- a/ModuleManagerTests/PatchProgressTest.cs
+++ b/ModuleManagerTests/PatchProgressTest.cs
@@ -152,6 +152,66 @@ namespace ModuleManagerTests
         }
 
         [Fact]
+        public void TestNeedsUnsatisfiedBefore()
+        {
+            UrlDir.UrlConfig config1 = UrlBuilder.CreateConfig("abc/def", new ConfigNode("SOME_NODE"));
+            UrlDir.UrlConfig config2 = UrlBuilder.CreateConfig("ghi/jkl", new ConfigNode("SOME_OTHER_NODE"));
+
+            Assert.Equal(0, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(0, progress.NeedsUnsatisfiedRootCount);
+
+            progress.NeedsUnsatisfiedBefore(config1);
+            Assert.Equal(1, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(1, progress.NeedsUnsatisfiedRootCount);
+            logger.Received().Info("Deleting root node in file abc/def node: SOME_NODE as it can't satisfy its BEFORE");
+
+            progress.NeedsUnsatisfiedBefore(config2);
+            Assert.Equal(2, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(2, progress.NeedsUnsatisfiedRootCount);
+            logger.Received().Info("Deleting root node in file ghi/jkl node: SOME_OTHER_NODE as it can't satisfy its BEFORE");
+        }
+
+        [Fact]
+        public void TestNeedsUnsatisfiedFor()
+        {
+            UrlDir.UrlConfig config1 = UrlBuilder.CreateConfig("abc/def", new ConfigNode("SOME_NODE"));
+            UrlDir.UrlConfig config2 = UrlBuilder.CreateConfig("ghi/jkl", new ConfigNode("SOME_OTHER_NODE"));
+
+            Assert.Equal(0, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(0, progress.NeedsUnsatisfiedRootCount);
+
+            progress.NeedsUnsatisfiedFor(config1);
+            Assert.Equal(1, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(1, progress.NeedsUnsatisfiedRootCount);
+            logger.Received().Warning("Deleting root node in file abc/def node: SOME_NODE as it can't satisfy its FOR (this shouldn't happen)");
+
+            progress.NeedsUnsatisfiedFor(config2);
+            Assert.Equal(2, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(2, progress.NeedsUnsatisfiedRootCount);
+            logger.Received().Warning("Deleting root node in file ghi/jkl node: SOME_OTHER_NODE as it can't satisfy its FOR (this shouldn't happen)");
+        }
+
+        [Fact]
+        public void TestNeedsUnsatisfiedAfter()
+        {
+            UrlDir.UrlConfig config1 = UrlBuilder.CreateConfig("abc/def", new ConfigNode("SOME_NODE"));
+            UrlDir.UrlConfig config2 = UrlBuilder.CreateConfig("ghi/jkl", new ConfigNode("SOME_OTHER_NODE"));
+
+            Assert.Equal(0, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(0, progress.NeedsUnsatisfiedRootCount);
+
+            progress.NeedsUnsatisfiedAfter(config1);
+            Assert.Equal(1, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(1, progress.NeedsUnsatisfiedRootCount);
+            logger.Received().Info("Deleting root node in file abc/def node: SOME_NODE as it can't satisfy its AFTER");
+
+            progress.NeedsUnsatisfiedAfter(config2);
+            Assert.Equal(2, progress.NeedsUnsatisfiedCount);
+            Assert.Equal(2, progress.NeedsUnsatisfiedRootCount);
+            logger.Received().Info("Deleting root node in file ghi/jkl node: SOME_OTHER_NODE as it can't satisfy its AFTER");
+        }
+
+        [Fact]
         public void TestError()
         {
             UrlDir.UrlConfig config1 = UrlBuilder.CreateConfig("abc/def", new ConfigNode("SOME_NODE"));

--- a/TestUtils/URLBuilder.cs
+++ b/TestUtils/URLBuilder.cs
@@ -41,7 +41,15 @@ namespace TestUtils
 
         public static UrlDir CreateDir(string url, UrlDir parent = null)
         {
-            if (parent == null) parent = CreateRoot();
+            if (parent == null)
+            {
+                parent = CreateRoot();
+            }
+            else
+            {
+                UrlDir existingDir = parent.GetDirectory(url);
+                if (existingDir != null) return existingDir;
+            }
 
             UrlDir current = parent;
 
@@ -74,10 +82,17 @@ namespace TestUtils
                 parent = CreateRoot();
             }
 
+            string nameWithoutExtension = Path.GetFileNameWithoutExtension(name);
+            string extension = Path.GetExtension(name);
+            if (!string.IsNullOrEmpty(extension)) extension = extension.Substring(1);
+
+            UrlDir.UrlFile existingFile = parent.files.FirstOrDefault(f => f.name == nameWithoutExtension && f.fileExtension == extension);
+            if (existingFile != null) return existingFile;
+
             bool cfg = false;
             string newName = name;
 
-            if (Path.GetExtension(name) == ".cfg")
+            if (extension == "cfg")
             {
                 cfg = true;
                 newName = name + ".not_cfg";
@@ -87,7 +102,7 @@ namespace TestUtils
 
             if (cfg)
             {
-                UrlFile__field__name.SetValue(file, Path.GetFileNameWithoutExtension(name));
+                UrlFile__field__name.SetValue(file, nameWithoutExtension);
                 UrlFile__field__fileExtension.SetValue(file, "cfg");
                 UrlFile__field__fileType.SetValue(file, UrlDir.FileType.Config);
             }

--- a/TestUtilsTests/UrlBuilderTest.cs
+++ b/TestUtilsTests/UrlBuilderTest.cs
@@ -82,6 +82,8 @@ namespace TestUtilsTests
             Assert.Same(root, root.root);
             Assert.Same(root, parent.root);
             Assert.Same(root, dir.root);
+
+            Assert.Contains(dir, root.AllDirectories);
         }
 
         [Fact]
@@ -105,6 +107,32 @@ namespace TestUtilsTests
 
             Assert.Same(root, dir.root);
             Assert.Same(root, parent2.root);
+
+            Assert.Contains(dir, root.AllDirectories);
+            Assert.Contains(dir, parent1.AllDirectories);
+        }
+
+        [Fact]
+        public void TestCreateDir__Url__AlreadyExists()
+        {
+            UrlDir root = UrlBuilder.CreateRoot();
+
+            UrlDir dir1 = UrlBuilder.CreateDir("abc/def", root);
+            UrlDir dir2 = UrlBuilder.CreateDir("abc/def", root);
+
+            Assert.Same(dir1, dir2);
+
+            Assert.Equal("def", dir1.name);
+
+            UrlDir parent = dir1.parent;
+
+            Assert.NotNull(parent);
+            Assert.Equal("abc", parent.name);
+            Assert.Contains(dir1, parent.children);
+
+            Assert.Same(root, dir1.root);
+            Assert.Same(root, parent.root);
+            Assert.Contains(dir1, root.AllDirectories);
         }
 
         [Fact]
@@ -197,6 +225,31 @@ namespace TestUtilsTests
         }
 
         [Fact]
+        public void TestCreateFile__Url__AlreadyExists()
+        {
+            UrlDir root = UrlBuilder.CreateRoot();
+            UrlDir.UrlFile file1 = UrlBuilder.CreateFile("abc/def.txt", root);
+            UrlDir.UrlFile file2 = UrlBuilder.CreateFile("abc/def.txt", root);
+
+            Assert.Same(file1, file2);
+
+            Assert.Equal("def", file1.name);
+            Assert.Equal("txt", file1.fileExtension);
+            Assert.Equal(UrlDir.FileType.Unknown, file1.fileType);
+            Assert.Equal("abc/def", file1.url);
+
+            UrlDir parent1 = file1.parent;
+            Assert.NotNull(parent1);
+            Assert.Equal("abc", parent1.name);
+            Assert.Contains(file1, parent1.files);
+
+            Assert.Same(root, file1.root);
+            Assert.Same(root, parent1.root);
+
+            Assert.Contains(file1, root.AllFiles);
+        }
+
+        [Fact]
         public void TestCreateConfig()
         {
             ConfigNode node = new TestConfigNode("SOME_NODE")
@@ -254,6 +307,55 @@ namespace TestUtilsTests
 
             Assert.Contains(config, root.AllConfigs);
             Assert.Contains(config, root.GetConfigs("SOME_NODE"));
+        }
+
+        [Fact]
+        public void TestCreateConfig__Url__FileAlreadyExists()
+        {
+            UrlDir root = UrlBuilder.CreateRoot();
+
+            ConfigNode node1 = new TestConfigNode("SOME_NODE")
+            {
+                { "name", "blah" },
+                { "foo", "bar" },
+            };
+
+            ConfigNode node2 = new TestConfigNode("SOME_OTHER_NODE")
+            {
+                { "name", "bleh" },
+                { "jazz", "hands" },
+            };
+
+            UrlDir.UrlConfig config1 = UrlBuilder.CreateConfig("abc/def", node1, root);
+            UrlDir.UrlConfig config2 = UrlBuilder.CreateConfig("abc/def", node2, root);
+
+            UrlDir.UrlFile file = config1.parent;
+            Assert.NotNull(file);
+
+            Assert.Same(file, config2.parent);
+            
+            Assert.Equal("def", file.name);
+            Assert.Equal("cfg", file.fileExtension);
+            Assert.Equal(UrlDir.FileType.Config, file.fileType);
+            Assert.Contains(config1, file.configs);
+            Assert.Contains(config2, file.configs);
+
+            UrlDir parent = file.parent;
+            Assert.NotNull(parent);
+            Assert.Equal("abc", parent.name);
+            Assert.Contains(file, parent.files);
+
+            Assert.Contains(parent, root.children);
+
+            Assert.Same(root, file.root);
+            Assert.Same(root, parent.root);
+            Assert.Same(root, root.root);
+
+            Assert.Contains(config1, root.AllConfigs);
+            Assert.Contains(config1, root.GetConfigs("SOME_NODE"));
+
+            Assert.Contains(config2, root.AllConfigs);
+            Assert.Contains(config2, root.GetConfigs("SOME_OTHER_NODE"));
         }
     }
 }


### PR DESCRIPTION
Sorting the passes and removing them from the game database before applying resulted in a ~10% decrease in patch time on my test install (about 10k patches applied).

Note, this branch causes certain previously silent errors to become loud, for instance, having multiple passes on the same patch