### PR TITLE
Allow 0 or many spaces before operator

### DIFF
--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -711,7 +711,7 @@ namespace ModuleManager
         #region Applying Patches
 
         // Name is group 1, index is group 2, vector related filed is group 3, vector separator is group 4, operator is group 5
-        private static Regex parseValue = new Regex(@"([\w\&\-\.\?\*]+(?:,[^*\d][\w\&\-\.\?\*]*)*)(?:,(-?[0-9\*]+))?(?:\[((?:[0-9\*]+)+)(?:,(.))?\])?(?:\s([+\-*/^!]))?");
+        private static Regex parseValue = new Regex(@"([\w\&\-\.\?\*]+(?:,[^*\d][\w\&\-\.\?\*]*)*)(?:,(-?[0-9\*]+))?(?:\[((?:[0-9\*]+)+)(?:,(.))?\])?(?:\s*([+\-*/^!]))?");
 
         // Path is group 1, operator is group 5
         private static Regex parseAssign = new Regex(@"(.*)(?:\s)+([+\-*/^!])?");


### PR DESCRIPTION
When applying an operator (`+\-*/^!`) to a value there must be exactly one whitespace character before the operator, this allows 0 or more than one.