### PR TITLE
Support building on non-windows platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,8 +106,6 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 
-
-ModuleManager.csproj
 ModuleManager.csproj.user
 
 ModuleManager.*.dll

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -136,11 +136,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>echo copying to "%25KSPDIR%25\GameData\"
-"C:\Games\Tools\pdb2mdb\pdb2mdb.exe" $(TargetFileName)
-xcopy /Y "$(TargetPath)" "C:\Games\ksp-win_dev\GameData\"
-xcopy /Y "$(TargetDir)$(TargetName).pdb" "C:\Games\ksp-win_dev\GameData\"
-xcopy /Y "$(TargetDir)$(TargetName).dll.mdb" "C:\Games\ksp-win_dev\GameData\"
-del "C:\Games\ksp-win_dev\GameData\ModuleManager.ConfigCache"</PostBuildEvent>
+    <PostBuildEvent>sh -c "TARGET_PATH='$(TargetPath)' TARGET_DIR='$(TargetDir)' TARGET_NAME='$(TargetName)' sh '$(ProjectDir)/copy_build.sh'"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/ModuleManager/copy_build.sh
+++ b/ModuleManager/copy_build.sh
@@ -1,0 +1,45 @@
+if [ -z "${TARGET_PATH}" ] ; then
+  echo 'Expected $TARGET_PATH to be defined but it is not' >&2
+  exit 1
+elif ! [ -f "${TARGET_PATH}" ] ; then
+  echo 'Expected $TARGET_PATH to be a file but it is not' >&2
+  exit 1
+fi
+
+if [ -z "${TARGET_DIR}" ] ; then
+  echo 'Expected $TARGET_DIR to be defined but it is not' >&2
+  exit 1
+elif ! [ -d "${TARGET_DIR}" ] ; then
+  echo 'Expected $TARGET_DIR to be a directory but it is not' >&2
+  exit 1
+fi
+
+if [ -z "${TARGET_NAME}" ] ; then
+  echo 'Expected $TARGET_NAME to be defined but it is not' >&2
+  exit 1
+fi
+
+if [ -z "${PDB2MDB}" ] ; then
+  echo '$PDB2MDB not found'
+else
+  echo "Running '${PDB2MDB}'"
+  "${PDB2MDB}" "${TARGET_PATH}"
+fi
+
+if [ -z "${KSPDIR}" ] ; then
+  echo '$KSPDIR not found'
+else
+  if ! [ -d "${KSPDIR}" ] ; then
+    echo 'Expected $KSPDIR to point to a directory but it is not' >&2
+    exit 1
+  fi
+  if ! [ -d "${KSPDIR}/GameData" ] ; then
+    echo 'Expected $KSPDIR to contain a GameData subdirectory but it does not' >&2
+    exit 1
+  fi
+  echo "Copying to '${KSPDIR}'"
+  cp "${TARGET_PATH}" "${KSPDIR}/GameData/"
+  test -f "${TARGET_DIR}/${TARGET_NAME}.pdb" && cp "${TARGET_DIR}/${TARGET_NAME}.pdb" "${KSPDIR}/GameData/"
+  test -f "${TARGET_DIR}/${TARGET_NAME}.dll.mdb" && cp "${TARGET_DIR}/${TARGET_NAME}.dll.mdb" "${KSPDIR}/GameData/"
+  rm -f "${KSPDIR}/GameData/ModuleManager.ConfigCache"
+fi


### PR DESCRIPTION
Requires `sh` to be installed on Windows.  Relies on `$PDB2MDB` to find the `pdb2mdb` executable, and `$KSPDIR` to find where to copy to.  If either of these are absent, it will be ignored (but the build will still work)