### PR TITLE
Allow parentheses in value name

### DIFF
--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -712,7 +712,7 @@ namespace ModuleManager
         #region Applying Patches
 
         // Name is group 1, index is group 2, vector related filed is group 3, vector separator is group 4, operator is group 5
-        private static Regex parseValue = new Regex(@"([\w\&\-\.\?\*+/^!]+(?:,[^*\d][\w\&\-\.\?\*]*)*)(?:,(-?[0-9\*]+))?(?:\[((?:[0-9\*]+)+)(?:,(.))?\])?(?:\s*([+\-*/^!]))?");
+        private static Regex parseValue = new Regex(@"([\w\&\-\.\?\*+/^!\(\)]+(?:,[^*\d][\w\&\-\.\?\*\(\)]*)*)(?:,(-?[0-9\*]+))?(?:\[((?:[0-9\*]+)+)(?:,(.))?\])?(?:\s*([+\-*/^!]))?");
 
         // Path is group 1, operator is group 5
         private static Regex parseAssign = new Regex(@"(.*)(?:\s)+([+\-*/^!])?");


### PR DESCRIPTION
A use case came up with `ModulePartVariants` - if you want to switch entire models
```
GAMEOBJECTS
{
    path/to/model(Clone) = true
}
```

This works outside a MM patch, but not inside a patch (the `(Clone)` part gets stripped off).

It doesn't look like this will cause a conflict with any existing features.