### PR TITLE
Fix value assignment with * indexer

### DIFF
--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -733,8 +733,12 @@ namespace ModuleManager
                 #endif
 
                 Command cmd = CommandParser.Parse(modVal.name, out string valName);
-
-                Operator op = OperatorParser.Parse(valName, out valName);
+                
+                Operator op;
+                if (valName.Length > 2 && valName[valName.Length - 2] == ',')
+                    op = Operator.Assign;
+                else
+                    op = OperatorParser.Parse(valName, out valName);
 
                 if (cmd == Command.Special)
                 {

--- a/ModuleManagerTests/MMPatchLoaderTest.cs
+++ b/ModuleManagerTests/MMPatchLoaderTest.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Xunit;
+using NSubstitute;
+using UnityEngine;
+using TestUtils;
+using ModuleManager;
+using ModuleManager.Logging;
+using ModuleManager.Progress;
+using NodeStack = ModuleManager.Collections.ImmutableStack<ConfigNode>;
+
+namespace ModuleManagerTests
+{
+    // This is not intended to fully test ModifyNode, however it is useful to include tests for bugfixes here before it is split up
+    public class MMPatchLoaderTest
+    {
+        private readonly IBasicLogger logger = Substitute.For<IBasicLogger>();
+        private readonly IPatchProgress progress = Substitute.For<IPatchProgress>();
+        private readonly UrlDir root = UrlBuilder.CreateRoot();
+
+        [Fact]
+        public void TestModifyNode__IndexAllWithAssign()
+        {
+            ConfigNode c1 = new TestConfigNode("NODE")
+            {
+                { "foo", "bar1" },
+                { "foo", "bar2" },
+            };
+
+            UrlDir.UrlConfig c2u = UrlBuilder.CreateConfig("abc/def", new TestConfigNode("@NODE")
+            {
+                { "@foo,*", "bar3" },
+            }, root);
+            
+            PatchContext context = new PatchContext(c2u, root, logger, progress);
+
+            ConfigNode c3 = MMPatchLoader.ModifyNode(new NodeStack(c1), c2u.config, context);
+
+            EnsureNoErrors();
+
+            AssertConfigNodesEqual(new TestConfigNode("NODE")
+            {
+                { "foo", "bar3" },
+                { "foo", "bar3" },
+            }, c3);
+        }
+
+        [Fact]
+        public void TestModifyNode__MultiplyValue()
+        {
+            ConfigNode c1 = new TestConfigNode("NODE")
+            {
+                { "foo", "3" },
+                { "foo", "5" },
+            };
+
+            UrlDir.UrlConfig c2u = UrlBuilder.CreateConfig("abc/def", new TestConfigNode("@NODE")
+            {
+                { "@foo *", "2" },
+            }, root);
+
+            PatchContext context = new PatchContext(c2u, root, logger, progress);
+
+            ConfigNode c3 = MMPatchLoader.ModifyNode(new NodeStack(c1), c2u.config, context);
+
+            EnsureNoErrors();
+
+            AssertConfigNodesEqual(new TestConfigNode("NODE")
+            {
+                { "foo", "6" },
+                { "foo", "5" },
+            }, c3);
+        }
+
+        private void AssertConfigNodesEqual(ConfigNode expected, ConfigNode observed)
+        {
+            Assert.Equal(expected.ToString(), observed.ToString());
+        }
+
+        private void EnsureNoErrors()
+        {
+            progress.DidNotReceiveWithAnyArgs().Error(null, null);
+            progress.DidNotReceiveWithAnyArgs().Exception(null, null);
+            progress.DidNotReceiveWithAnyArgs().Exception(null, null, null);
+
+            logger.DidNotReceive().Log(LogType.Warning, Arg.Any<string>());
+            logger.DidNotReceive().Log(LogType.Error, Arg.Any<string>());
+            logger.DidNotReceive().Log(LogType.Exception, Arg.Any<string>());
+        }
+    }
+}

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Extensions\StringExtensionsTest.cs" />
     <Compile Include="Extensions\UrlConfigExtensionsTest.cs" />
     <Compile Include="Logging\UnityLoggerTest.cs" />
+    <Compile Include="MMPatchLoaderTest.cs" />
     <Compile Include="NeedsCheckerTest.cs" />
     <Compile Include="Collections\MessageQueueTest.cs" />
     <Compile Include="Logging\ExceptionMessageTest.cs" />


### PR DESCRIPTION
Broken in #111 - probably an unusual case but it would have worked
before.

Added tests to ensure that this fixes it.  Tests are not and will
probably never cover all of MMPatchLoader.ModifyNode but useful to add
bugfix cases here as they occur.