### PR TITLE
Allow :NEEDS to check against subdirectories

### DIFF
--- a/ModuleManagerTests/NeedsCheckerTest.cs
+++ b/ModuleManagerTests/NeedsCheckerTest.cs
@@ -13,11 +13,11 @@ namespace ModuleManagerTests
 {
     public class NeedsCheckerTest
     {
-        private UrlDir root;
-        private UrlDir.UrlFile file;
+        private readonly UrlDir root;
+        private readonly UrlDir.UrlFile file;
 
-        private IPatchProgress progress;
-        private IBasicLogger logger;
+        private readonly IPatchProgress progress;
+        private readonly IBasicLogger logger;
 
         public NeedsCheckerTest()
         {

--- a/TestUtils/UrlBuilder.cs
+++ b/TestUtils/UrlBuilder.cs
@@ -7,6 +7,7 @@ namespace TestUtils
 {
     public static class UrlBuilder
     {
+        private static readonly FieldInfo UrlDir__field__type;
         private static readonly FieldInfo UrlDir__field__name;
         private static readonly FieldInfo UrlDir__field__root;
         private static readonly FieldInfo UrlDir__field__parent;
@@ -18,9 +19,11 @@ namespace TestUtils
         static UrlBuilder()
         {
             FieldInfo[] UrlDirFields = typeof(UrlDir).GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo[] UrlDirFields__DirectoryType = UrlDirFields.Where(field => field.FieldType == typeof(UrlDir.DirectoryType)).ToArray();
             FieldInfo[] UrlDirFields__string = UrlDirFields.Where(field => field.FieldType == typeof(string)).ToArray();
             FieldInfo[] UrlDirFields__UrlDir = UrlDirFields.Where(field => field.FieldType == typeof(UrlDir)).ToArray();
 
+            UrlDir__field__type = UrlDirFields__DirectoryType[0];
             UrlDir__field__name = UrlDirFields__string[0];
             UrlDir__field__root = UrlDirFields__UrlDir[0];
             UrlDir__field__parent = UrlDirFields__UrlDir[1];
@@ -65,6 +68,29 @@ namespace TestUtils
             }
 
             return current;
+        }
+
+        public static UrlDir CreateGameData(UrlDir root = null)
+        {
+            if (root == null)
+            {
+                root = CreateRoot();
+            }
+            else
+            {
+                UrlDir potentialGameData = root.children.FirstOrDefault(dir => dir.type == UrlDir.DirectoryType.GameData && dir.name == "");
+                if (potentialGameData != null) return potentialGameData;
+            }
+
+            UrlDir gameData = CreateRoot();
+            UrlDir__field__name.SetValue(gameData, "");
+            UrlDir__field__type.SetValue(gameData, UrlDir.DirectoryType.GameData);
+            UrlDir__field__root.SetValue(gameData, root);
+            UrlDir__field__parent.SetValue(gameData, root);
+
+            root.children.Add(gameData);
+
+            return gameData;
         }
 
         public static UrlDir.UrlFile CreateFile(string path, UrlDir parent = null)

--- a/TestUtils/UrlBuilder.cs
+++ b/TestUtils/UrlBuilder.cs
@@ -7,13 +7,13 @@ namespace TestUtils
 {
     public static class UrlBuilder
     {
-        private static FieldInfo UrlDir__field__name;
-        private static FieldInfo UrlDir__field__root;
-        private static FieldInfo UrlDir__field__parent;
+        private static readonly FieldInfo UrlDir__field__name;
+        private static readonly FieldInfo UrlDir__field__root;
+        private static readonly FieldInfo UrlDir__field__parent;
 
-        private static FieldInfo UrlFile__field__name;
-        private static FieldInfo UrlFile__field__fileType;
-        private static FieldInfo UrlFile__field__fileExtension;
+        private static readonly FieldInfo UrlFile__field__name;
+        private static readonly FieldInfo UrlFile__field__fileType;
+        private static readonly FieldInfo UrlFile__field__fileExtension;
 
         static UrlBuilder()
         {

--- a/TestUtilsTests/UrlBuilderTest.cs
+++ b/TestUtilsTests/UrlBuilderTest.cs
@@ -136,6 +136,45 @@ namespace TestUtilsTests
         }
 
         [Fact]
+        public void TestCreateGameData()
+        {
+            UrlDir gameData = UrlBuilder.CreateGameData();
+
+            Assert.Equal("", gameData.name);
+            Assert.Equal("", gameData.url);
+            Assert.Equal(UrlDir.DirectoryType.GameData, gameData.type);
+            UrlDir root = Assert.IsType<UrlDir>(gameData.root);
+            Assert.Same(root, gameData.parent);
+            Assert.Equal("root", root.name);
+            Assert.Null(root.parent);
+            Assert.Same(root, root.root);
+            Assert.Contains(gameData, root.children);
+        }
+
+        [Fact]
+        public void TestCreateGameData__SpecifyRoot()
+        {
+            UrlDir root = UrlBuilder.CreateRoot();
+            UrlDir gameData = UrlBuilder.CreateGameData(root);
+
+            Assert.Equal("", gameData.name);
+            Assert.Equal("", gameData.url);
+            Assert.Equal(UrlDir.DirectoryType.GameData, gameData.type);
+            Assert.Same(root, gameData.parent);
+            Assert.Contains(gameData, root.children);
+        }
+
+        [Fact]
+        public void TestCreateGameData__SpecifyRoot__GameDataAlreadyExists()
+        {
+            UrlDir root = UrlBuilder.CreateRoot();
+            UrlDir gameData1 = UrlBuilder.CreateGameData(root);
+            UrlDir gameData2 = UrlBuilder.CreateGameData(root);
+
+            Assert.Same(gameData1, gameData2);
+        }
+
+        [Fact]
         public void TestCreateFile()
         {
             UrlDir.UrlFile file = UrlBuilder.CreateFile("someFile.txt");


### PR DESCRIPTION
If some component of a `:NEEDS` block has a slash in it (and it doesn't already exist in the mod list), it will attempt to match against subdirectories of GameData

* `:BEFORE`, and `:AFTER` do not consider this logic
* Comparison is case-sensitive
* Leading/trailing slashes will be dropped but will be considered when deciding whether to check this as a path
* Multiple slashes together are treated as a single slash
* PluginData directories are excluded
* It checks against KSP's in-memory game database tree rather than what's physically there

Resolves #108