### PR TITLE
Fix wildcards in value names

### DIFF
--- a/ModuleManager/OperatorParser.cs
+++ b/ModuleManager/OperatorParser.cs
@@ -13,6 +13,11 @@ namespace ModuleManager
                 valueName = string.Empty;
                 return Operator.Assign;
             }
+            else if (name.Length == 1 || (name[name.Length - 2] != ' ' && name[name.Length - 2] != '\t'))
+            {
+                valueName = name;
+                return Operator.Assign;
+            }
 
             Operator ret;
             switch (name[name.Length - 1])

--- a/ModuleManagerTests/OperatorParserTest.cs
+++ b/ModuleManagerTests/OperatorParserTest.cs
@@ -88,5 +88,23 @@ namespace ModuleManagerTests
             Assert.Equal(Operator.RegexReplace, op);
             Assert.Equal("some_stuff,1[2, ]", result);
         }
+
+        [Fact]
+        public void TestParse__NoSpaceMeansNoOp()
+        {
+            Operator op = OperatorParser.Parse("some_stuff*", out string result);
+
+            Assert.Equal(Operator.Assign, op);
+            Assert.Equal("some_stuff*", result);
+        }
+
+        [Fact]
+        public void TestParse__SingleCharacterNotOp()
+        {
+            Operator op = OperatorParser.Parse("*", out string result);
+
+            Assert.Equal(Operator.Assign, op);
+            Assert.Equal("*", result);
+        }
     }
 }


### PR DESCRIPTION
Require at least one space before the operator.  If * appears in at the end of value
name without a space it should be interpreted as a wildcard rather than
the multiplication operator