### PR TITLE
Test projects target .NET 4

### DIFF
--- a/ModuleManagerTests/DummyTest.cs
+++ b/ModuleManagerTests/DummyTest.cs
@@ -8,7 +8,7 @@ namespace ModuleManagerTests
         [Fact]
         public void PassingTest()
         {
-            Assert.Equal(true, true);
+            Assert.True(true);
         }
     }
 }

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -8,6 +8,7 @@ namespace ModuleManagerTests.Extensions
 {
     public class ConfigNodeExtensionsTest
     {
+        [Fact]
         public void TestShallowCopyFrom()
         {
             ConfigNode fromNode = new TestConfigNode("SOME_NODE")

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -38,11 +38,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp" />
-    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.2.0.3\lib\net35\NSubstitute.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
@@ -99,6 +110,7 @@
     <Compile Include="Utils\CounterTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -59,8 +60,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine" />
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -126,6 +137,9 @@
       <Name>TestUtils</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -133,5 +147,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
   </Target>
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
-  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -116,7 +116,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props'))" />
   </Target>
 </Project>

--- a/ModuleManagerTests/ModuleManagerTests.csproj
+++ b/ModuleManagerTests/ModuleManagerTests.csproj
@@ -11,10 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ModuleManagerTests</RootNamespace>
     <AssemblyName>ModuleManagerTests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp" />

--- a/ModuleManagerTests/PatchExtractorTest.cs
+++ b/ModuleManagerTests/PatchExtractorTest.cs
@@ -307,7 +307,7 @@ namespace ModuleManagerTests
 
             patchCompiler.DidNotReceiveWithAnyArgs().CompilePatch(null);
         
-            Assert.Equal(1, root.AllConfigs.Count());
+            Assert.Single(root.AllConfigs);
             UrlDir.UrlConfig newUrlConfig = root.AllConfigs.First();
             Assert.NotSame(urlConfig, newUrlConfig);
             Assert.NotSame(urlConfig.config, newUrlConfig.config);

--- a/ModuleManagerTests/Patches/CopyPatchTest.cs
+++ b/ModuleManagerTests/Patches/CopyPatchTest.cs
@@ -232,7 +232,7 @@ namespace ModuleManagerTests.Patches
 
             patch.Apply(file, progress, logger);
 
-            Assert.Equal(1, file.configs.Count);
+            Assert.Single(file.configs);
 
             Assert.Same(urlConfig, file.configs[0]);
             AssertNodesEqual(new TestConfigNode("NODE")

--- a/ModuleManagerTests/Patches/EditPatchTest.cs
+++ b/ModuleManagerTests/Patches/EditPatchTest.cs
@@ -178,7 +178,7 @@ namespace ModuleManagerTests.Patches
 
             patch.Apply(file, progress, logger);
 
-            Assert.Equal(1, file.configs.Count);
+            Assert.Single(file.configs);
             Assert.NotSame(urlConfig, file.configs[0]);
             AssertNodesEqual(new TestConfigNode("NODE")
             {

--- a/ModuleManagerTests/Patches/PatchCompilerTest.cs
+++ b/ModuleManagerTests/Patches/PatchCompilerTest.cs
@@ -50,7 +50,7 @@ namespace ModuleManagerTests.Patches
 
             progress.Received().ApplyingUpdate(urlConfig, protoPatch.urlConfig);
 
-            Assert.Equal(1, file.configs.Count);
+            Assert.Single(file.configs);
             Assert.NotSame(urlConfig, file.configs[0]);
             AssertNodesEqual(new TestConfigNode("NODE")
             {
@@ -137,7 +137,7 @@ namespace ModuleManagerTests.Patches
 
             progress.Received().ApplyingDelete(urlConfig, protoPatch.urlConfig);
 
-            Assert.Equal(0, file.configs.Count);
+            Assert.Empty(file.configs);
         }
 
         [Fact]

--- a/ModuleManagerTests/app.config
+++ b/ModuleManagerTests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/ModuleManagerTests/packages.config
+++ b/ModuleManagerTests/packages.config
@@ -4,7 +4,13 @@
   <package id="NSubstitute" version="3.1.0" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
-  <package id="xunit" version="1.9.2" targetFramework="net35" />
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
   <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/ModuleManagerTests/packages.config
+++ b/ModuleManagerTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="2.0.3" targetFramework="net35" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net35" requireReinstallation="true" />
   <package id="xunit" version="1.9.2" targetFramework="net35" />
-  <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/ModuleManagerTests/packages.config
+++ b/ModuleManagerTests/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="2.0.3" targetFramework="net35" requireReinstallation="true" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net471" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
   <package id="xunit" version="1.9.2" targetFramework="net35" />
   <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />

--- a/ModuleManagerTests/packages.config
+++ b/ModuleManagerTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="NSubstitute" version="2.0.3" targetFramework="net35" />
   <package id="xunit" version="1.9.2" targetFramework="net35" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net35" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net35" developmentDependency="true" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TestUtils/TestUtils.csproj
+++ b/TestUtils/TestUtils.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestUtils</RootNamespace>
     <AssemblyName>TestUtils</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp" />

--- a/TestUtilsTests/DummyTest.cs
+++ b/TestUtilsTests/DummyTest.cs
@@ -8,7 +8,7 @@ namespace TestUtilsTests
         [Fact]
         public void PassingTest()
         {
-            Assert.Equal(true, true);
+            Assert.True(true);
         }
     }
 }

--- a/TestUtilsTests/TestUtilsTests.csproj
+++ b/TestUtilsTests/TestUtilsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -69,7 +69,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props'))" />
   </Target>
 </Project>

--- a/TestUtilsTests/TestUtilsTests.csproj
+++ b/TestUtilsTests/TestUtilsTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -45,8 +46,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine" />
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -67,6 +78,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -74,5 +88,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
   </Target>
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/TestUtilsTests/TestUtilsTests.csproj
+++ b/TestUtilsTests/TestUtilsTests.csproj
@@ -11,10 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestUtilsTests</RootNamespace>
     <AssemblyName>TestUtilsTests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp" />

--- a/TestUtilsTests/packages.config
+++ b/TestUtilsTests/packages.config
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="1.9.2" targetFramework="net35" />
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
   <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TestUtilsTests/packages.config
+++ b/TestUtilsTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net35" />
-  <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TestUtilsTests/packages.config
+++ b/TestUtilsTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net35" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net35" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net35" developmentDependency="true" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net35" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net35" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Apparently Visual Studio requires this to run tests now.  It appears to be the case that the console runner would be running against .NET 4 anyway.  The main project remains on .NET 3.5 since KSP requires that.