### PR TITLE
Workaround for 1.6.0 PartDatabase rebuild

### DIFF
--- a/ModuleManager/Fix16.cs
+++ b/ModuleManager/Fix16.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections;
+
+namespace ModuleManager
+{
+    class Fix16 : LoadingSystem
+    {
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                DestroyImmediate(this);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private static Fix16 Instance { get; set; }
+
+        private bool ready;
+
+        private int count;
+
+        private int current;
+
+        private const int yieldStep = 20;
+
+        public override bool IsReady()
+        {
+            return ready;
+        }
+
+        public override string ProgressTitle()
+        {
+            return "Fix 1.6.0 " + current + "/" + count;
+        }
+
+        public override float ProgressFraction()
+        {
+            return (float) current / count;
+        }
+
+        public override void StartLoad()
+        {
+            ready = false;
+            
+            count = PartLoader.LoadedPartsList.Count;
+
+            StartCoroutine(DoFix());
+        }
+
+        private IEnumerator DoFix()
+        {
+            int yieldCounter = 0;
+            for (current = 0; current < count; current++)
+            {
+                AvailablePart avp = PartLoader.LoadedPartsList[current];
+                if (avp.partPrefab.dragModel == Part.DragModel.CUBE && !avp.partPrefab.DragCubes.Procedural &&
+                    !avp.partPrefab.DragCubes.None && avp.partPrefab.DragCubes.Cubes.Count == 0)
+                {
+                    DragCubeSystem.Instance.LoadDragCubes(avp.partPrefab);
+                }
+
+                if (yieldCounter++ >= yieldStep)
+                {
+                    yieldCounter = 0;
+                    yield return null;
+                }
+            }
+
+            ready = true;
+            yield return null;
+        }
+
+        public override float LoadWeight()
+        {
+            return 0.1f;
+        }
+    }
+}

--- a/ModuleManager/ModuleManager.cs
+++ b/ModuleManager/ModuleManager.cs
@@ -128,6 +128,13 @@ namespace ModuleManager
 
                 int gameDatabaseIndex = list.FindIndex(s => s is GameDatabase);
                 list.Insert(gameDatabaseIndex + 1, loader);
+
+                // Workaround for 1.6.0 Editor bug after a PartDatabase rebuild.
+                if (Versioning.version_major == 1 && Versioning.version_minor == 6 && Versioning.Revision == 0)
+                {
+                    Fix16 fix16 = aGameObject.AddComponent<Fix16>();
+                    list.Add(fix16);
+                }
             }
 
             bool foolsDay = (DateTime.Now.Month == 4 && DateTime.Now.Day == 1);

--- a/ModuleManager/ModuleManager.csproj
+++ b/ModuleManager/ModuleManager.csproj
@@ -31,6 +31,7 @@
     <ConsolePause>False</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Fix16.cs" />
     <Compile Include="Cats\CatAnimator.cs" />
     <Compile Include="Cats\CatManager.cs" />
     <Compile Include="Cats\CatMover.cs" />

--- a/ModuleManager/Properties/AssemblyInfo.cs
+++ b/ModuleManager/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("3.1.2")]
+[assembly: AssemblyVersion("3.1.3")]
 [assembly: KSPAssembly("ModuleManager", 2, 5)]
 
 // The following attributes are used to specify the signing key for the assembly, 


### PR DESCRIPTION
This add a loader that makes sure all parts DragCubes are properly loaded before the editor. This prevents the triggering of a Squad bug in 1.6.0