### PR TITLE
Allow assemblies to add to mod list

### DIFF
--- a/ModuleManager/MMPatchRunner.cs
+++ b/ModuleManager/MMPatchRunner.cs
@@ -48,9 +48,13 @@ namespace ModuleManager
             // Wait for game database to be initialized for the 2nd time
             yield return null;
 
+            IBasicLogger mmLogger = new QueueLogger(mmLogQueue);
+
+            IEnumerable<ModListGenerator.ModAddedByAssembly> modsAddedByAssemblies = ModListGenerator.GetAdditionalModsFromStaticMethods(mmLogger);
+
             IEnumerable<IProtoUrlConfig> databaseConfigs = null;
 
-            MMPatchLoader patchLoader = new MMPatchLoader(new QueueLogger(mmLogQueue));
+            MMPatchLoader patchLoader = new MMPatchLoader(modsAddedByAssemblies, mmLogger);
 
             ITaskStatus patchingThreadStatus = BackgroundTask.Start(delegate
             {

--- a/ModuleManager/MMPatchRunner.cs
+++ b/ModuleManager/MMPatchRunner.cs
@@ -45,7 +45,8 @@ namespace ModuleManager
                 }
             });
 
-            // Wait for game database to be initialized for the 2nd time
+            // Wait for game database to be initialized for the 2nd time and wait for any plugins to initialize
+            yield return null;
             yield return null;
 
             IBasicLogger mmLogger = new QueueLogger(mmLogQueue);


### PR DESCRIPTION
Fix to allow Kerbalism to define some feature toggles

Allow ModuleManagerAddToModList callback to be defined as a static method or on MonoBehaviour instances which returns an IEnumerable<string> to be added to the mod list

It will always be called on the main thread

Result will also be added to the config sha to ensure proper cache invalidation