### PR TITLE
Better experience with slow patching

### DIFF
--- a/ModuleManager/ModuleManager.cs
+++ b/ModuleManager/ModuleManager.cs
@@ -33,6 +33,7 @@ namespace ModuleManager
         private bool nyan = false;
         private bool nCats = false;
         public static bool dumpPostPatch = false;
+        public static bool DontCopyLogs { get; private set; } = false;
 
         private PopupDialog menu;
 
@@ -151,6 +152,8 @@ namespace ModuleManager
                 || Environment.GetCommandLineArgs().Contains("-ncats");
 
             dumpPostPatch = Environment.GetCommandLineArgs().Contains("-mm-dump");
+
+            DontCopyLogs = Environment.GetCommandLineArgs().Contains("-mm-dont-copy-logs");
 
             loadedInScene = true;
         }

--- a/ModuleManager/PostPatchLoader.cs
+++ b/ModuleManager/PostPatchLoader.cs
@@ -26,6 +26,8 @@ namespace ModuleManager
 
         private bool ready = false;
 
+        private string progressTitle = "ModuleManager: Post patch";
+
         public static void AddPostPatchCallback(ModuleManagerPostPatchCallback callback)
         {
             if (!postPatchCallbacks.Contains(callback))
@@ -48,7 +50,7 @@ namespace ModuleManager
 
         public override float ProgressFraction() => 1;
 
-        public override string ProgressTitle() => "ModuleManager : post patch";
+        public override string ProgressTitle() => progressTitle;
 
         public override void StartLoad()
         {
@@ -61,6 +63,8 @@ namespace ModuleManager
             Stopwatch waitTimer = new Stopwatch();
             waitTimer.Start();
 
+            progressTitle = "ModuleManager: Waiting for patching to finish";
+
             while (databaseConfigs == null) yield return null;
 
             waitTimer.Stop();
@@ -69,6 +73,7 @@ namespace ModuleManager
             Stopwatch postPatchTimer = new Stopwatch();
             postPatchTimer.Start();
 
+            progressTitle = "ModuleManager: Applying patched game database";
             logger.Info("Applying patched game database");
 
             foreach (UrlDir.UrlFile file in GameDatabase.Instance.root.AllConfigFiles)
@@ -87,6 +92,7 @@ namespace ModuleManager
 
             if (File.Exists(logPath))
             {
+                progressTitle = "ModuleManager: Dumping log to KSP log";
                 logger.Info("Dumping ModuleManager log to main log");
                 logger.Info("\n#### BEGIN MODULEMANAGER LOG ####\n\n\n" + File.ReadAllText(logPath) + "\n\n\n#### END MODULEMANAGER LOG ####");
             }
@@ -104,6 +110,8 @@ namespace ModuleManager
 
             yield return null;
 
+            progressTitle = "ModuleManager: Reloading things";
+
             logger.Info("Reloading resources definitions");
             PartResourceLibrary.Instance.LoadDefinitions();
 
@@ -115,6 +123,7 @@ namespace ModuleManager
 
             yield return null;
 
+            progressTitle = "ModuleManager: Running post patch callbacks";
             logger.Info("Running post patch callbacks");
 
             foreach (ModuleManagerPostPatchCallback callback in postPatchCallbacks)

--- a/ModuleManager/PostPatchLoader.cs
+++ b/ModuleManager/PostPatchLoader.cs
@@ -92,9 +92,16 @@ namespace ModuleManager
 
             if (File.Exists(logPath))
             {
-                progressTitle = "ModuleManager: Dumping log to KSP log";
-                logger.Info("Dumping ModuleManager log to main log");
-                logger.Info("\n#### BEGIN MODULEMANAGER LOG ####\n\n\n" + File.ReadAllText(logPath) + "\n\n\n#### END MODULEMANAGER LOG ####");
+                if (ModuleManager.DontCopyLogs)
+                {
+                    logger.Info("Not dumping log because -mm-dont-copy-logs was set");
+                }
+                else
+                {
+                    progressTitle = "ModuleManager: Dumping log to KSP log";
+                    logger.Info("Dumping ModuleManager log to main log");
+                    logger.Info("\n#### BEGIN MODULEMANAGER LOG ####\n\n\n" + File.ReadAllText(logPath) + "\n\n\n#### END MODULEMANAGER LOG ####");
+                }
             }
             else
             {


### PR DESCRIPTION
* Provide more insight into what's going on during post patch
* Add `-mm-dont-copy-logs` command line flag - advanced users can opt out of copying MM logs to the main log which can save a significant amount of time on large installs