### PR TITLE
Properly handle tabs and newlines in node values

### DIFF
--- a/ModuleManager/Extensions/ConfigNodeExtensions.cs
+++ b/ModuleManager/Extensions/ConfigNodeExtensions.cs
@@ -19,7 +19,7 @@ namespace ModuleManager.Extensions
         {
             ConfigNode to = new ConfigNode(from.name);
             foreach (ConfigNode.Value value in from.values)
-                to.values.Add(new ConfigNode.Value(value.name, value.value));
+                to.AddValueSafe(value.name, value.value);
             foreach (ConfigNode node in from.nodes)
             {
                 ConfigNode newNode = DeepCopy(node);
@@ -67,6 +67,11 @@ namespace ModuleManager.Extensions
             }
 
             sb.AppendFormat("{0}}}\n", indent);
+        }
+
+        public static void AddValueSafe(this ConfigNode node, string name, string value)
+        {
+            node.values.Add(new ConfigNode.Value(name, value));
         }
     }
 }

--- a/ModuleManager/Extensions/ConfigNodeExtensions.cs
+++ b/ModuleManager/Extensions/ConfigNodeExtensions.cs
@@ -19,7 +19,7 @@ namespace ModuleManager.Extensions
         {
             ConfigNode to = new ConfigNode(from.name);
             foreach (ConfigNode.Value value in from.values)
-                to.AddValue(value.name, value.value);
+                to.values.Add(new ConfigNode.Value(value.name, value.value));
             foreach (ConfigNode node in from.nodes)
             {
                 ConfigNode newNode = DeepCopy(node);

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -430,11 +430,30 @@ namespace ModuleManager
 
             cache.AddValue("patchedNodeCount", patchedNodeCount.ToString());
 
+            // Undoes escaping done by the localizer
+            void FixValuesRecursive(ConfigNode theNode)
+            {
+                foreach (ConfigNode subNode in theNode.nodes)
+                {
+                    FixValuesRecursive(subNode);
+                }
+
+                foreach (ConfigNode.Value value in theNode.values)
+                {
+                    value.value = value.value.Replace("\n", "\\n");
+                    value.value = value.value.Replace("\t", "\\t");
+                }
+            }
+
             foreach (IProtoUrlConfig urlConfig in databaseConfigs)
             {
                 ConfigNode node = cache.AddNode("UrlConfig");
                 node.AddValue("parentUrl", urlConfig.UrlFile.GetUrlWithExtension());
-                node.AddNode(urlConfig.Node);
+
+                ConfigNode urlNode = urlConfig.Node.DeepCopy();
+                FixValuesRecursive(urlNode);
+
+                node.AddNode(urlNode);
             }
 
             foreach (var file in GameDatabase.Instance.root.AllConfigFiles)
@@ -524,6 +543,21 @@ namespace ModuleManager
 
             List<IProtoUrlConfig> databaseConfigs = new List<IProtoUrlConfig>(cache.nodes.Count);
 
+            // Evaluate escape sequences
+            void FixValuesRecursive(ConfigNode theNode)
+            {
+                foreach (ConfigNode subNode in theNode.nodes)
+                {
+                    FixValuesRecursive(subNode);
+                }
+
+                foreach (ConfigNode.Value value in theNode.values)
+                {
+                    value.value = value.value.Replace("\\n", "\n");
+                    value.value = value.value.Replace("\\t", "\t");
+                }
+            }
+
             foreach (ConfigNode node in cache.nodes)
             {
                 string parentUrl = node.GetValue("parentUrl");
@@ -531,6 +565,7 @@ namespace ModuleManager
                 UrlDir.UrlFile parent = gameDataDir.Find(parentUrl);
                 if (parent != null)
                 {
+                    FixValuesRecursive(node.nodes[0]);
                     databaseConfigs.Add(new ProtoUrlConfig(parent, node.nodes[0]));
                 }
                 else

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -725,7 +725,7 @@ namespace ModuleManager
                             if (varValue != null)
                             {
                                 newNode.RemoveValues(valName);
-                                newNode.AddValue(valName, varValue);
+                                newNode.AddValueSafe(valName, varValue);
                             }
                             else
                             {
@@ -771,7 +771,7 @@ namespace ModuleManager
                                     if (cmd != Command.Copy)
                                         origVal.value = value;
                                     else
-                                        newNode.AddValue(valName, value);
+                                        newNode.AddValueSafe(valName, value);
                                 }
                             }
                             else
@@ -847,7 +847,7 @@ namespace ModuleManager
                             if (varValue != null)
                             {
                                 if (!newNode.HasValue(valName))
-                                    newNode.AddValue(valName, varValue);
+                                    newNode.AddValueSafe(valName, varValue);
                             }
                             else
                             {
@@ -1010,8 +1010,8 @@ namespace ModuleManager
                             msg += "  Applying subnode " + subMod.name + "\n";
                             #endif
                             ConfigNode newSubNode = ModifyNode(nodeStack.Push(subNodes[0]), subMod, context);
-                            subNodes[0].ClearData();
-                            newSubNode.CopyTo(subNodes[0], newSubNode.name);
+                            subNodes[0].ShallowCopyFrom(newSubNode);
+                            subNodes[0].name = newSubNode.name;
                         }
                         else
                         {
@@ -1023,7 +1023,7 @@ namespace ModuleManager
                             ConfigNode copy = new ConfigNode(nodeType);
 
                             if (nodeName != null)
-                                copy.AddValue("name", nodeName);
+                                copy.AddValueSafe("name", nodeName);
 
                             ConfigNode newSubNode = ModifyNode(nodeStack.Push(copy), subMod, context);
                             newNode.nodes.Add(newSubNode);
@@ -1040,7 +1040,7 @@ namespace ModuleManager
                             ConfigNode copy = new ConfigNode(nodeType);
 
                             if (nodeName != null)
-                                copy.AddValue("name", nodeName);
+                                copy.AddValueSafe("name", nodeName);
 
                             ConfigNode newSubNode = ModifyNode(nodeStack.Push(copy), subMod, context);
                             newNode.nodes.Add(newSubNode);
@@ -1066,8 +1066,8 @@ namespace ModuleManager
 
                                     // Edit in place
                                     newSubNode = ModifyNode(nodeStack.Push(subNode), subMod, context);
-                                    subNode.ClearData();
-                                    newSubNode.CopyTo(subNode, newSubNode.name);
+                                    subNode.ShallowCopyFrom(newSubNode);
+                                    subNode.name = newSubNode.name;
                                     break;
 
                                 case Command.Delete:
@@ -1698,13 +1698,13 @@ namespace ModuleManager
                 newNode.RemoveValues(name);
                 int i = 0;
                 for (; i < index; ++i)
-                    newNode.AddValue(name, oldValues[i]);
-                newNode.AddValue(name, value);
+                    newNode.AddValueSafe(name, oldValues[i]);
+                newNode.AddValueSafe(name, value);
                 for (; i < oldValues.Length; ++i)
-                    newNode.AddValue(name, oldValues[i]);
+                    newNode.AddValueSafe(name, oldValues[i]);
                 return;
             }
-            newNode.AddValue(name, value);
+            newNode.AddValueSafe(name, value);
         }
 
         //FindConfigNodeIn finds and returns a ConfigNode in src of type nodeType.

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -49,13 +49,11 @@ namespace ModuleManagerTests.Extensions
 
             Assert.Same(value1, fromNode.values[0]);
             Assert.Same(value1, toNode.values[0]);
-            Assert.Equal("abc", value1.name);
-            Assert.Equal("def", value1.value);
+            AssertValue("abc", "def", value1);
 
             Assert.Same(value2, fromNode.values[1]);
             Assert.Same(value2, toNode.values[1]);
-            Assert.Equal("ghi", value2.name);
-            Assert.Equal("jkl", value2.value);
+            AssertValue("ghi", "jkl", value2);
 
             Assert.Equal(2, fromNode.nodes.Count);
             Assert.Equal(2, toNode.nodes.Count);
@@ -64,23 +62,21 @@ namespace ModuleManagerTests.Extensions
             Assert.Same(innerNode1, toNode.nodes[0]);
             Assert.Equal("INNER_NODE_1", innerNode1.name);
             Assert.Equal(1, innerNode1.values.Count);
-            Assert.Equal("mno", innerNode1.values[0].name);
-            Assert.Equal("pqr", innerNode1.values[0].value);
+            AssertValue("mno", "pqr", innerNode1.values[0]);
             Assert.Equal(1, innerNode1.nodes.Count);
             Assert.Equal("INNER_INNER_NODE_1", innerNode1.nodes[0].name);
-            Assert.Equal(0, innerNode1.nodes[0].values.Count);
-            Assert.Equal(0, innerNode1.nodes[0].nodes.Count);
+            Assert.Empty(innerNode1.nodes[0].values);
+            Assert.Empty(innerNode1.nodes[0].nodes);
 
             Assert.Same(innerNode2, fromNode.nodes[1]);
             Assert.Same(innerNode2, toNode.nodes[1]);
             Assert.Equal("INNER_NODE_2", innerNode2.name);
             Assert.Equal(1, innerNode2.values.Count);
-            Assert.Equal("stu", innerNode2.values[0].name);
-            Assert.Equal("vwx", innerNode2.values[0].value);
+            AssertValue("stu", "vwx", innerNode2.values[0]);
             Assert.Equal(1, innerNode2.nodes.Count);
             Assert.Equal("INNER_INNER_NODE_2", innerNode2.nodes[0].name);
-            Assert.Equal(0, innerNode2.nodes[0].values.Count);
-            Assert.Equal(0, innerNode2.nodes[0].nodes.Count);
+            Assert.Empty(innerNode2.nodes[0].values);
+            Assert.Empty(innerNode2.nodes[0].nodes);
         }
 
         [Fact]
@@ -109,13 +105,11 @@ namespace ModuleManagerTests.Extensions
             Assert.Equal(2, toNode.values.Count);
             
             Assert.NotSame(fromNode.values[0], toNode.values[0]);
-            Assert.Equal("abc", toNode.values[0].name);
-            Assert.Equal("def", toNode.values[0].value);
-            
+            AssertValue("abc", "def", toNode.values[0]);
+
             Assert.NotSame(fromNode.values[1], toNode.values[1]);
-            Assert.Equal("ghi", toNode.values[1].name);
-            Assert.Equal("jkl", toNode.values[1].value);
-            
+            AssertValue("ghi", "jkl", toNode.values[1]);
+
             Assert.Equal(2, toNode.nodes.Count);
 
             ConfigNode innerNode1 = toNode.nodes[0];
@@ -123,26 +117,24 @@ namespace ModuleManagerTests.Extensions
             Assert.Equal("INNER_NODE_1", innerNode1.name);
             Assert.Equal(1, innerNode1.values.Count);
             Assert.NotSame(fromNode.nodes[0].values[0], innerNode1.values[0]);
-            Assert.Equal("mno", innerNode1.values[0].name);
-            Assert.Equal("pqr", innerNode1.values[0].value);
+            AssertValue("mno", "pqr", innerNode1.values[0]);
             Assert.Equal(1, toNode.nodes[0].nodes.Count);
             Assert.NotSame(fromNode.nodes[0].nodes[0], innerNode1.nodes[0]);
             Assert.Equal("INNER_INNER_NODE_1", innerNode1.nodes[0].name);
-            Assert.Equal(0, innerNode1.nodes[0].values.Count);
-            Assert.Equal(0, innerNode1.nodes[0].nodes.Count);
+            Assert.Empty(innerNode1.nodes[0].values);
+            Assert.Empty(innerNode1.nodes[0].nodes);
 
             ConfigNode innerNode2 = toNode.nodes[1];
             Assert.NotSame(fromNode.nodes[1], innerNode2);
             Assert.Equal("INNER_NODE_2", innerNode2.name);
             Assert.Equal(1, innerNode2.values.Count);
             Assert.NotSame(fromNode.nodes[1].values[0], innerNode2.values[0]);
-            Assert.Equal("stu", innerNode2.values[0].name);
-            Assert.Equal("vwx", innerNode2.values[0].value);
+            AssertValue("stu", "vwx", innerNode2.values[0]);
             Assert.Equal(1, innerNode2.nodes.Count);
             Assert.NotSame(fromNode.nodes[1].nodes[0], innerNode2.nodes[0]);
             Assert.Equal("INNER_INNER_NODE_2", innerNode2.nodes[0].name);
-            Assert.Equal(0, innerNode2.nodes[0].values.Count);
-            Assert.Equal(0, innerNode2.nodes[0].nodes.Count);
+            Assert.Empty(innerNode2.nodes[0].values);
+            Assert.Empty(innerNode2.nodes[0].nodes);
         }
 
         [Fact]
@@ -272,6 +264,12 @@ XX}
             StringBuilder sb = new StringBuilder();
             node.PrettyPrint(ref sb, "XX");
             Assert.Equal(expected, sb.ToString());
+        }
+
+        private void AssertValue(string name, string value, ConfigNode.Value nodeValue)
+        {
+            Assert.Equal(name, nodeValue.name);
+            Assert.Equal(value, nodeValue.value);
         }
     }
 }

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -89,6 +89,7 @@ namespace ModuleManagerTests.Extensions
                 new TestConfigNode("INNER_NODE_1")
                 {
                     { "mno", "pqr" },
+                    { "weird_values", "some\r\n\tstuff" },
                     new TestConfigNode("INNER_INNER_NODE_1"),
                 },
                 new TestConfigNode("INNER_NODE_2")
@@ -115,9 +116,11 @@ namespace ModuleManagerTests.Extensions
             ConfigNode innerNode1 = toNode.nodes[0];
             Assert.NotSame(fromNode.nodes[0], innerNode1);
             Assert.Equal("INNER_NODE_1", innerNode1.name);
-            Assert.Equal(1, innerNode1.values.Count);
+            Assert.Equal(2, innerNode1.values.Count);
             Assert.NotSame(fromNode.nodes[0].values[0], innerNode1.values[0]);
             AssertValue("mno", "pqr", innerNode1.values[0]);
+            Assert.NotSame(fromNode.nodes[0].values[1], innerNode1.values[1]);
+            AssertValue("weird_values", "some\r\n\tstuff", innerNode1.values[1]);
             Assert.Equal(1, toNode.nodes[0].nodes.Count);
             Assert.NotSame(fromNode.nodes[0].nodes[0], innerNode1.nodes[0]);
             Assert.Equal("INNER_INNER_NODE_1", innerNode1.nodes[0].name);

--- a/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
+++ b/ModuleManagerTests/Extensions/ConfigNodeExtensionsTest.cs
@@ -269,6 +269,21 @@ XX}
             Assert.Equal(expected, sb.ToString());
         }
 
+        [Fact]
+        public void TestAddValueSafe()
+        {
+            ConfigNode node = new TestConfigNode
+            {
+                { "key1", "value1" },
+            };
+
+            node.AddValueSafe("weird_values", "some\r\n\tstuff");
+
+            Assert.Equal(2, node.values.Count);
+            AssertValue("key1", "value1", node.values[0]);
+            AssertValue("weird_values", "some\r\n\tstuff", node.values[1]);
+        }
+
         private void AssertValue(string name, string value, ConfigNode.Value nodeValue)
         {
             Assert.Equal(name, nodeValue.name);

--- a/ModuleManagerTests/MMPatchLoaderTest.cs
+++ b/ModuleManagerTests/MMPatchLoaderTest.cs
@@ -71,6 +71,84 @@ namespace ModuleManagerTests
             }, c3);
         }
 
+        [Fact]
+        public void TestModifyNode__EditNode__SpecialCharacters()
+        {
+            ConfigNode c1 = new TestConfigNode("NODE")
+            {
+                new TestConfigNode("INNER_NODE")
+                {
+                    { "weird_values", "some\r\n\tstuff" },
+                },
+            };
+
+            UrlDir.UrlConfig c2u = UrlBuilder.CreateConfig("abc/def", new TestConfigNode("@NODE")
+            {
+                new TestConfigNode("@INNER_NODE")
+                {
+                    { "another_weird_value", "some\r\nmore\tstuff" },
+                },
+            });
+
+            PatchContext context = new PatchContext(c2u, Enumerable.Empty<IProtoUrlConfig>(), logger, progress);
+
+            ConfigNode c3 = MMPatchLoader.ModifyNode(new NodeStack(c1), c2u.config, context);
+
+            EnsureNoErrors();
+
+            AssertConfigNodesEqual(new TestConfigNode("NODE")
+            {
+                new TestConfigNode("INNER_NODE")
+                {
+                    { "weird_values", "some\r\n\tstuff" },
+                    { "another_weird_value", "some\r\nmore\tstuff" },
+                },
+            }, c3);
+        }
+
+        [Fact]
+        public void TestModifyNode__ReplaceNode__SpecialCharacters()
+        {
+            ConfigNode c1 = new TestConfigNode("NODE")
+            {
+                new TestConfigNode("INNER_NODE")
+                {
+                    { "weird_values", "some\r\n\tstuff" },
+                },
+            };
+
+            UrlDir.UrlConfig c2u = UrlBuilder.CreateConfig("abc/def", new TestConfigNode("@NODE")
+            {
+                new TestConfigNode("%INNER_NODE")
+                {
+                    { "another_weird_value", "some\r\nmore\tstuff" },
+                },
+                new TestConfigNode("%OTHER_INNER_NODE")
+                {
+                    { "another_weirder_value", "even\r\nmore\tstuff" },
+                },
+            });
+
+            PatchContext context = new PatchContext(c2u, Enumerable.Empty<IProtoUrlConfig>(), logger, progress);
+
+            ConfigNode c3 = MMPatchLoader.ModifyNode(new NodeStack(c1), c2u.config, context);
+
+            EnsureNoErrors();
+
+            AssertConfigNodesEqual(new TestConfigNode("NODE")
+            {
+                new TestConfigNode("INNER_NODE")
+                {
+                    { "weird_values", "some\r\n\tstuff" },
+                    { "another_weird_value", "some\r\nmore\tstuff" },
+                },
+                new TestConfigNode("OTHER_INNER_NODE")
+                {
+                    { "another_weirder_value", "even\r\nmore\tstuff" },
+                },
+            }, c3);
+        }
+
         private void AssertConfigNodesEqual(ConfigNode expected, ConfigNode observed)
         {
             Assert.Equal(expected.ToString(), observed.ToString());

--- a/TestUtils/TestConfigNode.cs
+++ b/TestUtils/TestConfigNode.cs
@@ -8,7 +8,7 @@ namespace TestUtils
         public TestConfigNode() : base() { }
         public TestConfigNode(string name) : base(name) { }
 
-        public void Add(string name, string value) => AddValue(name, value);
+        public void Add(string name, string value) => Add(new Value(name, value));
         public void Add(Value value) => values.Add(value);
         public void Add(string name, ConfigNode node) => AddNode(name, node);
         public void Add(ConfigNode node) => AddNode(node);

--- a/TestUtils/TestConfigNode.cs
+++ b/TestUtils/TestConfigNode.cs
@@ -9,7 +9,7 @@ namespace TestUtils
         public TestConfigNode(string name) : base(name) { }
 
         public void Add(string name, string value) => AddValue(name, value);
-        public void Add(ConfigNode.Value value) => values.Add(value);
+        public void Add(Value value) => values.Add(value);
         public void Add(string name, ConfigNode node) => AddNode(name, node);
         public void Add(ConfigNode node) => AddNode(node);
 

--- a/TestUtilsTests/TestConfigNodeTest.cs
+++ b/TestUtilsTests/TestConfigNodeTest.cs
@@ -34,31 +34,40 @@ namespace TestUtilsTests
                 },
             };
 
-            Assert.Equal("something", node.GetValue("value1"));
-            Assert.Equal("something else", node.GetValue("value2"));
-            Assert.Equal(new[] { "first", "second" }, node.GetValues("multiple"));
-            Assert.Equal("bar", node.GetValue("foo"));
+            Assert.Equal(5, node.values.Count);
+            AssertValue("value1", "something", node.values[0]);
+            AssertValue("value2", "something else", node.values[1]);
+            AssertValue("multiple", "first", node.values[2]);
+            AssertValue("multiple", "second", node.values[3]);
+            AssertValue("foo", "bar", node.values[4]);
 
+            Assert.Equal(3, node.nodes.Count);
             ConfigNode innerNode1 = node.GetNode("NODE_1");
             Assert.NotNull(innerNode1);
 
-            Assert.Equal("NODE_1", innerNode1.name);
-            Assert.Equal("something", innerNode1.GetValue("name"));
-            Assert.Equal("something else", innerNode1.GetValue("stuff"));
+            Assert.Equal("NODE_1", node.nodes[0].name);
+            Assert.Equal(2, node.nodes[0].values.Count);
+            AssertValue("name", "something", node.nodes[0].values[0]);
+            AssertValue("stuff", "something else", node.nodes[0].values[1]);
+            Assert.Empty(node.nodes[0].nodes);
 
-            ConfigNode[] innerNodes2 = node.GetNodes("MULTIPLE");
-            Assert.NotNull(innerNodes2);
-            Assert.Equal(2, innerNodes2.Length);
+            Assert.Equal("MULTIPLE", node.nodes[1].name);
+            Assert.Equal(2, node.nodes[1].values.Count);
+            AssertValue("value3", "blah", node.nodes[1].values[0]);
+            AssertValue("value4", "bleh", node.nodes[1].values[1]);
+            Assert.Empty(node.nodes[1].nodes);
 
-            ConfigNode innerNode2a = innerNodes2[0];
-            Assert.NotNull(innerNode2a);
-            Assert.Equal("blah", innerNode2a.GetValue("value3"));
-            Assert.Equal("bleh", innerNode2a.GetValue("value4"));
+            Assert.Equal("MULTIPLE", node.nodes[2].name);
+            Assert.Equal(2, node.nodes[2].values.Count);
+            AssertValue("value3", "blih", node.nodes[2].values[0]);
+            AssertValue("value4", "bloh", node.nodes[2].values[1]);
+            Assert.Empty(node.nodes[2].nodes);
+        }
 
-            ConfigNode innerNode2b = innerNodes2[1];
-            Assert.NotNull(innerNode2b);
-            Assert.Equal("blih", innerNode2b.GetValue("value3"));
-            Assert.Equal("bloh", innerNode2b.GetValue("value4"));
+        private void AssertValue(string name, string value, ConfigNode.Value nodeValue)
+        {
+            Assert.Equal(name, nodeValue.name);
+            Assert.Equal(value, nodeValue.value);
         }
     }
 }

--- a/TestUtilsTests/TestConfigNodeTest.cs
+++ b/TestUtilsTests/TestConfigNodeTest.cs
@@ -16,6 +16,7 @@ namespace TestUtilsTests
                 { "multiple", "first" },
                 { "multiple", "second" },
                 new ConfigNode.Value("foo", "bar"),
+                { "weird_values", "some\r\n\tstuff" },
                 { "NODE_1", new TestConfigNode
                     {
                         { "name", "something" },
@@ -34,12 +35,13 @@ namespace TestUtilsTests
                 },
             };
 
-            Assert.Equal(5, node.values.Count);
+            Assert.Equal(6, node.values.Count);
             AssertValue("value1", "something", node.values[0]);
             AssertValue("value2", "something else", node.values[1]);
             AssertValue("multiple", "first", node.values[2]);
             AssertValue("multiple", "second", node.values[3]);
             AssertValue("foo", "bar", node.values[4]);
+            AssertValue("weird_values", "some\r\n\tstuff", node.values[5]);
 
             Assert.Equal(3, node.nodes.Count);
             ConfigNode innerNode1 = node.GetNode("NODE_1");


### PR DESCRIPTION
KSP strips them out in `ConfigNode.AddValue(string, string)`, meaning the cache didn't break but the newlines would get removed from strings.

This fixes some that in some `ConfigNode` modifying code, and makes sure that the cache also handles it properly

Resolves #84