### PR TITLE
Update MMPatchLoader.cs

### DIFF
--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -103,6 +103,18 @@ namespace ModuleManager
                 patchLogger.Info(status);
                 IEnumerable<string> mods = ModListGenerator.GenerateModList(modsAddedByAssemblies, progress, patchLogger);
 
+                //Begin static part database substitution code.  Use static template rather than outright deleting partDatabase
+                string pathToStaticDB = Path.Combine(KSPUtil.ApplicationRootPath, "StaticPartDatabase.dbk");
+                if (keepPartDB == false && File.Exists(pathToStaticDB))
+                {
+                    if (File.Exists(partDatabasePath))
+                    {
+                        File.Delete(partDatabasePath);
+                    }
+                        File.Copy(pathToStaticDB, partDatabasePath);
+                        keepPartDB = true;
+                }
+
                 // If we don't use the cache then it is best to clean the PartDatabase.cfg
                 if (!keepPartDB && File.Exists(partDatabasePath))
                     File.Delete(partDatabasePath);


### PR DESCRIPTION
The commit basically says it all here.

As to why this is needed:  1.8 has SIGNIFICANT drag calculation issues as noted here.

https://forum.kerbalspaceprogram.com/index.php?/topic/189064-investigating-significant-drag-and-heating-changes-introduced-in-180/

Substituting the old PartDatabase.cfg works around this issue, and new entries like the new boosters are auto-regenerated.  However, this becomes unreliable with a modded install with ModuleManager, which often wipes the file completely and eliminates the users desired "static" settings (in this case, the 1.7 ones).

This added code checks for a file named "StaticPartDatabase.dbk" in the KSP root.  If found, it uses this as a template instead of completely deleting/blanking the file.  If the file is not present behavior is unchanged.  This allows easily

I'm not sure whether you want to mainline this.  I plan on releasing binaries with this patch soon (along with some prep scripts for 1.7 exporting, and yes, there will be telltale signs in the logs of my patchset) and could continue to maintain that if need be, but it seems like a good/useful feature.  To be clear (doubt I need to say this, but...)

I hereby grant you all rights to use and customize this limited code snippet and general idea in all capacities  as you see fit.

Original commit log entry follows:

Add static template support for PartDatabase.cfg, using filename StaticPartDatabase.dbk.  This helps greatly when drag goes crazy as the user can sub in an older db or hand edit as needed.

This fork/commit is for pull request reasons only.