### PR TITLE
Fix :LAST

### DIFF
--- a/ModuleManager/MMPatchRunner.cs
+++ b/ModuleManager/MMPatchRunner.cs
@@ -80,12 +80,14 @@ namespace ModuleManager
             {
                 kspLogger.Exception("The patching thread threw an exception", patchingThreadStatus.Exception);
                 FatalErrorHandler.HandleFatalError("The patching thread threw an exception");
+                yield break;
             }
 
             if (loggingThreadStatus.IsExitedWithError)
             {
                 kspLogger.Exception("The logging thread threw an exception", loggingThreadStatus.Exception);
                 FatalErrorHandler.HandleFatalError("The logging thread threw an exception");
+                yield break;
             }
 
             if (databaseConfigs == null)

--- a/ModuleManager/PatchList.cs
+++ b/ModuleManager/PatchList.cs
@@ -37,52 +37,24 @@ namespace ModuleManager
             public void AddLastPatch(IPatch patch) => lastPass.Add(patch ?? throw new ArgumentNullException(nameof(patch)));
         }
 
-        private class ModPassCollection : IEnumerable<ModPass>
-        {
-            private readonly ModPass[] passesArray;
-            private readonly Dictionary<string, ModPass> passesDict;
-
-            public ModPassCollection(IEnumerable<string> modList)
-            {
-                int count = modList.Count();
-                passesArray = new ModPass[count];
-                passesDict = new Dictionary<string, ModPass>(count);
-
-                int i = 0;
-                foreach (string mod in modList)
-                {
-                    ModPass pass = new ModPass(mod);
-                    passesArray[i] = pass;
-                    passesDict.Add(mod.ToLowerInvariant(), pass);
-                    i++;
-                }
-            }
-
-            public ModPass this[string name] => passesDict[name.ToLowerInvariant()];
-            public ModPass this[int index] => passesArray[index];
-
-            public bool HasMod(string name) => passesDict.ContainsKey(name.ToLowerInvariant());
-
-            public int Count => passesArray.Length;
-
-            public ArrayEnumerator<ModPass> GetEnumerator() => new ArrayEnumerator<ModPass>(passesArray);
-            IEnumerator<ModPass> IEnumerable<ModPass>.GetEnumerator() => GetEnumerator();
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
         private readonly Pass insertPatches = new Pass(":INSERT (initial)");
         private readonly Pass firstPatches = new Pass(":FIRST");
         private readonly Pass legacyPatches = new Pass(":LEGACY (default)");
         private readonly Pass finalPatches = new Pass(":FINAL");
 
-        private readonly ModPassCollection modPasses;
+        private readonly SortedDictionary<string, ModPass> modPasses = new SortedDictionary<string, ModPass>(StringComparer.InvariantCultureIgnoreCase);
         private readonly SortedDictionary<string, Pass> lastPasses = new SortedDictionary<string, Pass>(StringComparer.InvariantCultureIgnoreCase);
 
         public PatchList(IEnumerable<string> modList, IEnumerable<IPatch> patches, IPatchProgress progress)
         {
-            modPasses = new ModPassCollection(modList ?? throw new ArgumentNullException(nameof(modList)));
+            if (modList == null) throw new ArgumentNullException(nameof(modList));
             if (patches == null) throw new ArgumentNullException(nameof(patches));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
+
+            foreach (string mod in modList)
+            {
+                modPasses.Add(mod, new ModPass(mod));
+            }
 
             foreach (IPatch patch in patches)
             {
@@ -141,7 +113,7 @@ namespace ModuleManager
             yield return firstPatches;
             yield return legacyPatches;
 
-            foreach (ModPass modPass in modPasses)
+            foreach (ModPass modPass in modPasses.Values)
             {
                 yield return modPass.beforePass;
                 yield return modPass.forPass;
@@ -162,7 +134,7 @@ namespace ModuleManager
         {
             if (mod == null) throw new ArgumentNullException(nameof(mod));
             if (mod == string.Empty) throw new ArgumentException("can't be empty", nameof(mod));
-            if (!modPasses.HasMod(mod)) throw new KeyNotFoundException($"Mod '{mod}' not found");
+            if (!modPasses.ContainsKey(mod)) throw new KeyNotFoundException($"Mod '{mod}' not found");
         }
     }
 }

--- a/ModuleManagerTests/PatchListTest.cs
+++ b/ModuleManagerTests/PatchListTest.cs
@@ -113,6 +113,7 @@ namespace ModuleManagerTests
                 Substitute.For<IPatch>(),
                 Substitute.For<IPatch>(),
                 Substitute.For<IPatch>(),
+                Substitute.For<IPatch>(),
             };
 
             UrlDir.UrlConfig urlConfig = UrlBuilder.CreateConfig("abc/def", new ConfigNode("NODE"));
@@ -139,8 +140,9 @@ namespace ModuleManagerTests
             patches[19].PassSpecifier.Returns(new AfterPassSpecifier("MOD2", urlConfig));
             patches[20].PassSpecifier.Returns(new LastPassSpecifier("mod2"));
             patches[21].PassSpecifier.Returns(new LastPassSpecifier("MOD2"));
-            patches[22].PassSpecifier.Returns(new FinalPassSpecifier());
+            patches[22].PassSpecifier.Returns(new LastPassSpecifier("mod3"));
             patches[23].PassSpecifier.Returns(new FinalPassSpecifier());
+            patches[24].PassSpecifier.Returns(new FinalPassSpecifier());
 
             patches[00].CountsAsPatch.Returns(false);
             patches[01].CountsAsPatch.Returns(false);
@@ -166,6 +168,7 @@ namespace ModuleManagerTests
             patches[21].CountsAsPatch.Returns(true);
             patches[22].CountsAsPatch.Returns(true);
             patches[23].CountsAsPatch.Returns(true);
+            patches[24].CountsAsPatch.Returns(true);
 
             IPatchProgress progress = Substitute.For<IPatchProgress>();
 
@@ -173,7 +176,7 @@ namespace ModuleManagerTests
 
             IPass[] passes = patchList.ToArray();
 
-            Assert.Equal(12, passes.Length);
+            Assert.Equal(13, passes.Length);
 
             Assert.Equal(":INSERT (initial)", passes[0].Name);
             Assert.Equal(new[] { patches[0], patches[1] }, passes[0]);
@@ -208,10 +211,13 @@ namespace ModuleManagerTests
             Assert.Equal(":LAST[MOD2]", passes[10].Name);
             Assert.Equal(new[] { patches[20], patches[21] }, passes[10]);
 
-            Assert.Equal(":FINAL", passes[11].Name);
-            Assert.Equal(new[] { patches[22], patches[23] }, passes[11]);
+            Assert.Equal(":LAST[MOD3]", passes[11].Name);
+            Assert.Equal(new[] { patches[22] }, passes[11]);
 
-            progress.Received(22).PatchAdded();
+            Assert.Equal(":FINAL", passes[12].Name);
+            Assert.Equal(new[] { patches[23], patches[24] }, passes[12]);
+
+            progress.Received(23).PatchAdded();
         }
     }
 }


### PR DESCRIPTION
It was NRE'ing when a mod wasn't present

Per the original design (#96) `:LAST` patches will always run regardless of whether the mod is present, in order

Resolves #159