### PR TITLE
Fix early physics

### DIFF
--- a/ModuleManager/CustomConfigsManager.cs
+++ b/ModuleManager/CustomConfigsManager.cs
@@ -16,16 +16,6 @@ namespace ModuleManager
                 Log("Setting modded tech tree as the active one");
                 HighLogic.CurrentGame.Parameters.Career.TechTreeUrl = techTreeFile;
             }
-
-            if (PhysicsGlobals.PhysicsDatabaseFilename != physicsFile && File.Exists(physicsPath))
-            {
-                Log("Setting modded physics as the active one");
-
-                PhysicsGlobals.PhysicsDatabaseFilename = physicsFile;
-
-                if (!PhysicsGlobals.Instance.LoadDatabase())
-                    Log("Something went wrong while setting the active physics config.");
-            }
         }
 
         public static void Log(String s)

--- a/ModuleManager/PostPatchLoader.cs
+++ b/ModuleManager/PostPatchLoader.cs
@@ -214,8 +214,6 @@ namespace ModuleManager
 
         private void LoadModdedPhysics()
         {
-            if (PhysicsGlobals.PhysicsDatabaseFilename == physicsFile) return;
-
             if (!File.Exists(physicsPath))
             {
                 logger.Error("Physics file not found");

--- a/ModuleManager/PostPatchLoader.cs
+++ b/ModuleManager/PostPatchLoader.cs
@@ -130,6 +130,8 @@ namespace ModuleManager
             logger.Info("Reloading Part Upgrades");
             PartUpgradeManager.Handler.FillUpgrades();
 
+            LoadModdedPhysics();
+
             yield return null;
 
             progressTitle = "ModuleManager: Running post patch callbacks";
@@ -208,6 +210,24 @@ namespace ModuleManager
             logger.Info("Post patch ran in " + ((float)postPatchTimer.ElapsedMilliseconds / 1000).ToString("F3") + "s");
 
             ready = true;
+        }
+
+        private void LoadModdedPhysics()
+        {
+            if (PhysicsGlobals.PhysicsDatabaseFilename == physicsFile) return;
+
+            if (!File.Exists(physicsPath))
+            {
+                logger.Error("Physics file not found");
+                return;
+            }
+
+            logger.Info("Setting modded physics as the active one");
+
+            PhysicsGlobals.PhysicsDatabaseFilename = physicsFile;
+
+            if (!PhysicsGlobals.Instance.LoadDatabase())
+                logger.Error("Something went wrong while setting the active physics config.");
         }
     }
 }


### PR DESCRIPTION
Part loader now relies on physics values (for e.g. minimum rigidbody mass), so we want to set modded physics earlier