### PR TITLE
Fix off-by-one string indexing in constraint checking

### DIFF
--- a/ModuleManager/Extensions/StringExtensions.cs
+++ b/ModuleManager/Extensions/StringExtensions.cs
@@ -30,7 +30,7 @@ namespace ModuleManager.Extensions
             if (str == null) throw new ArgumentNullException(nameof(str));
             if (value == null) throw new ArgumentNullException(nameof(value));
 
-            index = str.IndexOf(value, StringComparison.Ordinal);
+            index = str.IndexOf(value, StringComparison.CurrentCultureIgnoreCase);
             return index != -1;
         }
     }

--- a/ModuleManager/Extensions/StringExtensions.cs
+++ b/ModuleManager/Extensions/StringExtensions.cs
@@ -30,7 +30,7 @@ namespace ModuleManager.Extensions
             if (str == null) throw new ArgumentNullException(nameof(str));
             if (value == null) throw new ArgumentNullException(nameof(value));
 
-            index = str.IndexOf(value, StringComparison.CurrentCultureIgnoreCase);
+            index = str.IndexOf(value, StringComparison.Ordinal);
             return index != -1;
         }
     }

--- a/ModuleManager/MMPatchLoader.cs
+++ b/ModuleManager/MMPatchLoader.cs
@@ -1548,7 +1548,7 @@ namespace ModuleManager
                 string remainingConstraints = "";
                 if (constraints.Contains(":HAS[", out int hasStart))
                 {
-                    hasStart += 4;
+                    hasStart += 5;
                     remainingConstraints = constraints.Substring(hasStart, constraintList[0].LastIndexOf(']') - hasStart);
                     constraints = constraints.Substring(0, hasStart - 5);
                 }


### PR DESCRIPTION
Fixes #170, #172.

~~Also change string comparison type to `StringComparison.Ordinal`, which should be the correct type according to https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings.~~