### PR TITLE
Added , FileShare.ReadWrite to the File.Open, to allow MM to read files

### DIFF
--- a/ModuleManager/Utils/FileUtils.cs
+++ b/ModuleManager/Utils/FileUtils.cs
@@ -12,7 +12,7 @@ namespace ModuleManager.Utils
             if (!File.Exists(filename)) throw new FileNotFoundException("File does not exist", filename);
 
             using SHA256 sha = SHA256.Create();
-            using FileStream fs = File.Open(filename, FileMode.Open, FileAccess.Read);
+            using FileStream fs = File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             byte[] data = sha.ComputeHash(fs);
 
             return data.ToHex();


### PR DESCRIPTION
which are already opened by KSP

This seems to be a problem on extremely fast computers, I ran into this on my new system, this patch eliminated the exceptions