### PR TITLE
Fix invalid modded physics cfg path being fed to KSP when using the faulty PDLauncher workaround

### DIFF
--- a/ModuleManager/PostPatchLoader.cs
+++ b/ModuleManager/PostPatchLoader.cs
@@ -222,7 +222,7 @@ namespace ModuleManager
 
             logger.Info("Setting modded physics as the active one");
 
-            PhysicsGlobals.PhysicsDatabaseFilename = physicsFile;
+            PhysicsGlobals.PhysicsDatabaseFilename = physicsPath;
 
             if (!PhysicsGlobals.Instance.LoadDatabase())
                 logger.Error("Something went wrong while setting the active physics config.");


### PR DESCRIPTION
MM is currently using relative path, not absolute. When the user has set up the faulty PDLauncher workaround then relative paths will be broken. I believe this issue will stay around forever thanks to a particular youtuber's video coming up as top result and teaching the broken bypass method.